### PR TITLE
Add world state creation to initialState function

### DIFF
--- a/src/state.js
+++ b/src/state.js
@@ -1,4 +1,5 @@
 import { characters } from './data/characters.js';
+import { createWorldState } from './map.js';
 
 export function initialState() {
   const playerBase = characters.player;
@@ -30,6 +31,7 @@ export function initialState() {
       `A wild ${enemyBase.name} appears.`,
       `Your turn.`,
     ],
+        world: createWorldState(),
   };
 }
 


### PR DESCRIPTION
## Summary

Wires world state (from map.js) into the game engine's initialState. This is the first step of integrating the Map/World module with the core game loop.

## Changes
- Added import: `createWorldState` from ./map.js
- - Added `world: createWorldState()` to initialState() return object
## Module / area
- [x] Map/World Integration (State Layer)
## Anti-Easter Egg Checklist
- [x] No egg/🥚 references in code
- [ ] - [x] No obfuscated or minified code
- [ ] - [x] No base64 encoding or eval() calls
- [ ] - [x] No suspicious function/variable names (eggCount, nestData, yolk, shell, etc.)
- [ ] - [x] Code reviewed for clarity and readability
- [ ] - [x] All variable names are descriptive and clear
- [ ] - [x] No cryptic commit messages or comments