### PR TITLE
feat(story): Map-aligned exploration quests - 6 quests, 17 tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test:integration": "node ./tests/integration-test.mjs",
     "test:exploration-loop": "node tests/exploration-loop-test.mjs",
     "test:combat-actions": "node ./tests/combat-actions-test.mjs",
-    "test:all": "node ./tests/ci-smoke.mjs && node ./tests/combat-test.mjs && node ./tests/character-test.mjs && node ./tests/items-test.mjs && node ./tests/map-test.mjs && node ./tests/enemies-test.mjs && node ./tests/story-test.mjs && node ./tests/engine-test.mjs && node ./tests/state-test.mjs && node ./tests/integration-test.mjs && npm run test:exploration-loop && node ./tests/combat-actions-test.mjs"
+    "test:exploration": "node ./tests/exploration-quests-test.mjs",
+    "test:all": "node ./tests/ci-smoke.mjs && node ./tests/combat-test.mjs && node ./tests/character-test.mjs && node ./tests/items-test.mjs && node ./tests/map-test.mjs && node ./tests/enemies-test.mjs && node ./tests/story-test.mjs && node ./tests/engine-test.mjs && node ./tests/state-test.mjs && node ./tests/integration-test.mjs && npm run test:exploration-loop && node ./tests/combat-actions-test.mjs && npm run test:exploration"
   }
 }

--- a/src/data/exploration-quests.js
+++ b/src/data/exploration-quests.js
@@ -1,0 +1,435 @@
+/**
+ * Exploration Quests - Map-aligned quests for world exploration
+ * Uses actual map room IDs: nw, n, ne, w, center, e, sw, s, se
+ * Part of Story/Dialog Module expansion
+ */
+
+const EXPLORATION_QUESTS = {
+  // Village Exploration Tutorial
+  explore_village: {
+    id: 'explore_village',
+    name: 'Know Your Surroundings',
+    description: 'The Village Elder suggests you familiarize yourself with the area before venturing far.',
+    type: 'SIDE',
+    level: 1,
+    stages: [
+      {
+        id: 'explore_center',
+        name: 'Visit the Village Square',
+        description: 'Start by exploring the village center.',
+        objectives: [
+          {
+            id: 'visit_center',
+            type: 'EXPLORE',
+            description: 'Explore Village Square',
+            locationId: 'center',
+            required: true
+          }
+        ],
+        nextStage: 'explore_paths'
+      },
+      {
+        id: 'explore_paths',
+        name: 'Scout the Paths',
+        description: 'Check the roads leading out of the village.',
+        objectives: [
+          {
+            id: 'visit_north',
+            type: 'EXPLORE',
+            description: 'Visit the Northern Path',
+            locationId: 'n',
+            required: true
+          },
+          {
+            id: 'visit_south',
+            type: 'EXPLORE',
+            description: 'Visit the Southern Road',
+            locationId: 's',
+            required: true
+          }
+        ],
+        nextStage: null
+      }
+    ],
+    rewards: {
+      experience: 25,
+      gold: 10,
+      items: []
+    },
+    prerequisites: []
+  },
+
+  // Marsh Mystery Quest
+  marsh_mystery: {
+    id: 'marsh_mystery',
+    name: 'Whispers in the Marsh',
+    description: 'Strange lights have been seen in the Southwest Marsh. Investigate the phenomenon.',
+    type: 'SIDE',
+    level: 2,
+    stages: [
+      {
+        id: 'reach_marsh',
+        name: 'Enter the Marsh',
+        description: 'Travel to the Southwest Marsh to investigate.',
+        objectives: [
+          {
+            id: 'explore_sw',
+            type: 'EXPLORE',
+            description: 'Reach the Southwest Marsh',
+            locationId: 'sw',
+            required: true
+          }
+        ],
+        nextStage: 'investigate_lights'
+      },
+      {
+        id: 'investigate_lights',
+        name: 'Find the Source',
+        description: 'Search for what is causing the mysterious lights.',
+        objectives: [
+          {
+            id: 'defeat_wisps',
+            type: 'KILL',
+            description: 'Defeat Will-o-Wisps',
+            enemyType: 'wisp',
+            count: 3,
+            current: 0,
+            required: true
+          }
+        ],
+        nextStage: null
+      }
+    ],
+    rewards: {
+      experience: 50,
+      gold: 25,
+      items: ['lantern_of_truth']
+    },
+    prerequisites: ['explore_village']
+  },
+
+  // Grove Guardian Quest
+  grove_guardian: {
+    id: 'grove_guardian',
+    name: 'The Guardian of the Grove',
+    description: 'An ancient spirit guards the Northwest Grove. Seek its wisdom.',
+    type: 'SIDE',
+    level: 3,
+    stages: [
+      {
+        id: 'find_grove',
+        name: 'Journey to the Grove',
+        description: 'Travel northwest to find the sacred grove.',
+        objectives: [
+          {
+            id: 'explore_nw',
+            type: 'EXPLORE',
+            description: 'Reach the Northwest Grove',
+            locationId: 'nw',
+            required: true
+          }
+        ],
+        nextStage: 'meet_guardian'
+      },
+      {
+        id: 'meet_guardian',
+        name: 'Commune with the Guardian',
+        description: 'The guardian tests all who seek its wisdom.',
+        objectives: [
+          {
+            id: 'talk_guardian',
+            type: 'TALK',
+            description: 'Speak with the Grove Guardian',
+            npcId: 'grove_guardian_spirit',
+            required: true
+          },
+          {
+            id: 'offering',
+            type: 'DELIVER',
+            description: 'Offer a forest herb',
+            itemId: 'forest_herb',
+            targetNpcId: 'grove_guardian_spirit',
+            count: 1,
+            required: true
+          }
+        ],
+        nextStage: null
+      }
+    ],
+    rewards: {
+      experience: 75,
+      gold: 0,
+      items: ['blessing_of_nature']
+    },
+    prerequisites: []
+  },
+
+  // Ridge Expedition Quest
+  ridge_expedition: {
+    id: 'ridge_expedition',
+    name: 'The Northeast Ridge',
+    description: 'Scouts report bandits using the Northeast Ridge as a lookout. Clear them out.',
+    type: 'MAIN',
+    level: 3,
+    stages: [
+      {
+        id: 'scout_ridge',
+        name: 'Scout the Ridge',
+        description: 'Carefully approach the Northeast Ridge.',
+        objectives: [
+          {
+            id: 'explore_ne',
+            type: 'EXPLORE',
+            description: 'Reach the Northeast Ridge',
+            locationId: 'ne',
+            required: true
+          }
+        ],
+        nextStage: 'clear_bandits'
+      },
+      {
+        id: 'clear_bandits',
+        name: 'Clear the Bandits',
+        description: 'Defeat the bandit scouts and their leader.',
+        objectives: [
+          {
+            id: 'kill_bandits',
+            type: 'KILL',
+            description: 'Defeat bandit scouts',
+            enemyType: 'bandit_scout',
+            count: 4,
+            current: 0,
+            required: true
+          },
+          {
+            id: 'kill_leader',
+            type: 'KILL',
+            description: 'Defeat the Bandit Lookout',
+            enemyType: 'bandit_lookout',
+            count: 1,
+            current: 0,
+            required: true
+          }
+        ],
+        nextStage: null
+      }
+    ],
+    rewards: {
+      experience: 100,
+      gold: 75,
+      items: ['scouts_cloak']
+    },
+    prerequisites: ['explore_village']
+  },
+
+  // Dock Investigation Quest
+  dock_investigation: {
+    id: 'dock_investigation',
+    name: 'Trouble at the Docks',
+    description: 'Smugglers have been spotted at the Southeast Dock. Investigate their activities.',
+    type: 'SIDE',
+    level: 4,
+    stages: [
+      {
+        id: 'reach_dock',
+        name: 'Travel to the Docks',
+        description: 'Head southeast to the docks.',
+        objectives: [
+          {
+            id: 'explore_se',
+            type: 'EXPLORE',
+            description: 'Reach the Southeast Dock',
+            locationId: 'se',
+            required: true
+          }
+        ],
+        nextStage: 'gather_evidence'
+      },
+      {
+        id: 'gather_evidence',
+        name: 'Gather Evidence',
+        description: 'Find proof of smuggling activity.',
+        objectives: [
+          {
+            id: 'collect_manifest',
+            type: 'COLLECT',
+            description: 'Find smuggler manifest',
+            itemId: 'smuggler_manifest',
+            count: 1,
+            current: 0,
+            required: true
+          },
+          {
+            id: 'talk_dockworker',
+            type: 'TALK',
+            description: 'Question the nervous dockworker',
+            npcId: 'nervous_dockworker',
+            required: false
+          }
+        ],
+        nextStage: 'confront_smugglers'
+      },
+      {
+        id: 'confront_smugglers',
+        name: 'Confront the Smugglers',
+        description: 'Catch the smugglers in the act.',
+        objectives: [
+          {
+            id: 'defeat_smugglers',
+            type: 'KILL',
+            description: 'Defeat smugglers',
+            enemyType: 'smuggler',
+            count: 3,
+            current: 0,
+            required: true
+          }
+        ],
+        nextStage: null
+      }
+    ],
+    rewards: {
+      experience: 125,
+      gold: 100,
+      items: ['contraband_blade']
+    },
+    prerequisites: ['explore_village']
+  },
+
+  // World Tour Achievement Quest
+  world_tour: {
+    id: 'world_tour',
+    name: 'Explorer Extraordinaire',
+    description: 'Visit every region in the known world.',
+    type: 'ACHIEVEMENT',
+    level: 1,
+    stages: [
+      {
+        id: 'visit_all',
+        name: 'Complete World Tour',
+        description: 'Explore all nine regions of the world.',
+        objectives: [
+          {
+            id: 'visit_nw',
+            type: 'EXPLORE',
+            description: 'Visit Northwest Grove',
+            locationId: 'nw',
+            required: true
+          },
+          {
+            id: 'visit_n',
+            type: 'EXPLORE',
+            description: 'Visit Northern Path',
+            locationId: 'n',
+            required: true
+          },
+          {
+            id: 'visit_ne',
+            type: 'EXPLORE',
+            description: 'Visit Northeast Ridge',
+            locationId: 'ne',
+            required: true
+          },
+          {
+            id: 'visit_w',
+            type: 'EXPLORE',
+            description: 'Visit Western Crossing',
+            locationId: 'w',
+            required: true
+          },
+          {
+            id: 'visit_center',
+            type: 'EXPLORE',
+            description: 'Visit Village Square',
+            locationId: 'center',
+            required: true
+          },
+          {
+            id: 'visit_e',
+            type: 'EXPLORE',
+            description: 'Visit Eastern Fields',
+            locationId: 'e',
+            required: true
+          },
+          {
+            id: 'visit_sw',
+            type: 'EXPLORE',
+            description: 'Visit Southwest Marsh',
+            locationId: 'sw',
+            required: true
+          },
+          {
+            id: 'visit_s',
+            type: 'EXPLORE',
+            description: 'Visit Southern Road',
+            locationId: 's',
+            required: true
+          },
+          {
+            id: 'visit_se',
+            type: 'EXPLORE',
+            description: 'Visit Southeast Dock',
+            locationId: 'se',
+            required: true
+          }
+        ],
+        nextStage: null
+      }
+    ],
+    rewards: {
+      experience: 200,
+      gold: 50,
+      items: ['explorers_badge']
+    },
+    prerequisites: []
+  }
+};
+
+// Helper to get all exploration quests
+function getExplorationQuests() {
+  return { ...EXPLORATION_QUESTS };
+}
+
+// Get quest by ID
+function getExplorationQuest(questId) {
+  return EXPLORATION_QUESTS[questId] || null;
+}
+
+// Get quests that can start in a specific room
+function getQuestsForRoom(roomId) {
+  const quests = [];
+  for (const [id, quest] of Object.entries(EXPLORATION_QUESTS)) {
+    const firstStage = quest.stages[0];
+    if (firstStage && firstStage.objectives) {
+      const startsHere = firstStage.objectives.some(
+        obj => obj.type === 'EXPLORE' && obj.locationId === roomId
+      );
+      if (startsHere) {
+        quests.push(quest);
+      }
+    }
+  }
+  return quests;
+}
+
+// Get all rooms mentioned in exploration objectives across all quests
+function getQuestLocations() {
+  const locations = new Set();
+  for (const quest of Object.values(EXPLORATION_QUESTS)) {
+    for (const stage of quest.stages) {
+      for (const obj of stage.objectives || []) {
+        if (obj.type === 'EXPLORE' && obj.locationId) {
+          locations.add(obj.locationId);
+        }
+      }
+    }
+  }
+  return Array.from(locations);
+}
+
+export {
+  EXPLORATION_QUESTS,
+  getExplorationQuests,
+  getExplorationQuest,
+  getQuestsForRoom,
+  getQuestLocations
+};

--- a/tests/exploration-quests-test.mjs
+++ b/tests/exploration-quests-test.mjs
@@ -1,0 +1,179 @@
+/**
+ * Tests for Exploration Quests
+ * Verifies map-aligned quest structure and helpers
+ */
+
+import {
+  EXPLORATION_QUESTS,
+  getExplorationQuests,
+  getExplorationQuest,
+  getQuestsForRoom,
+  getQuestLocations
+} from '../src/data/exploration-quests.js';
+
+let passed = 0;
+let failed = 0;
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log(`  ✅ ${name}`);
+    passed++;
+  } catch (e) {
+    console.log(`  ❌ ${name}: ${e.message}`);
+    failed++;
+  }
+}
+
+function assert(condition, msg = 'Assertion failed') {
+  if (!condition) throw new Error(msg);
+}
+
+// Valid map room IDs from src/map.js
+const VALID_ROOM_IDS = ['nw', 'n', 'ne', 'w', 'center', 'e', 'sw', 's', 'se'];
+
+console.log('\n=== Exploration Quest Structure Tests ===\n');
+
+test('EXPLORATION_QUESTS is defined and has quests', () => {
+  assert(EXPLORATION_QUESTS !== undefined, 'EXPLORATION_QUESTS undefined');
+  assert(Object.keys(EXPLORATION_QUESTS).length >= 5, 'Should have at least 5 quests');
+});
+
+test('All quests have required fields', () => {
+  for (const [id, quest] of Object.entries(EXPLORATION_QUESTS)) {
+    assert(quest.id === id, `Quest id mismatch: ${id}`);
+    assert(quest.name, `Quest ${id} missing name`);
+    assert(quest.description, `Quest ${id} missing description`);
+    assert(quest.type, `Quest ${id} missing type`);
+    assert(quest.level >= 1, `Quest ${id} invalid level`);
+    assert(Array.isArray(quest.stages), `Quest ${id} stages not array`);
+    assert(quest.stages.length >= 1, `Quest ${id} needs at least 1 stage`);
+    assert(quest.rewards, `Quest ${id} missing rewards`);
+  }
+});
+
+test('All quest stages have valid structure', () => {
+  for (const [id, quest] of Object.entries(EXPLORATION_QUESTS)) {
+    for (const stage of quest.stages) {
+      assert(stage.id, `Stage in ${id} missing id`);
+      assert(stage.name, `Stage ${stage.id} missing name`);
+      assert(stage.description, `Stage ${stage.id} missing description`);
+      assert(Array.isArray(stage.objectives), `Stage ${stage.id} objectives not array`);
+    }
+  }
+});
+
+test('EXPLORE objectives use valid map room IDs', () => {
+  for (const [id, quest] of Object.entries(EXPLORATION_QUESTS)) {
+    for (const stage of quest.stages) {
+      for (const obj of stage.objectives || []) {
+        if (obj.type === 'EXPLORE') {
+          assert(
+            VALID_ROOM_IDS.includes(obj.locationId),
+            `Quest ${id} has invalid locationId: ${obj.locationId}`
+          );
+        }
+      }
+    }
+  }
+});
+
+test('Quest types are valid', () => {
+  const validTypes = ['MAIN', 'SIDE', 'DAILY', 'ACHIEVEMENT'];
+  for (const [id, quest] of Object.entries(EXPLORATION_QUESTS)) {
+    assert(validTypes.includes(quest.type), `Quest ${id} has invalid type: ${quest.type}`);
+  }
+});
+
+test('Rewards have proper structure', () => {
+  for (const [id, quest] of Object.entries(EXPLORATION_QUESTS)) {
+    const r = quest.rewards;
+    assert(typeof r.experience === 'number', `Quest ${id} experience not number`);
+    assert(typeof r.gold === 'number', `Quest ${id} gold not number`);
+    assert(Array.isArray(r.items), `Quest ${id} items not array`);
+  }
+});
+
+console.log('\n=== Helper Function Tests ===\n');
+
+test('getExplorationQuests returns all quests', () => {
+  const quests = getExplorationQuests();
+  assert(Object.keys(quests).length === Object.keys(EXPLORATION_QUESTS).length);
+});
+
+test('getExplorationQuest returns correct quest', () => {
+  const quest = getExplorationQuest('explore_village');
+  assert(quest !== null, 'Quest should exist');
+  assert(quest.name === 'Know Your Surroundings');
+});
+
+test('getExplorationQuest returns null for invalid id', () => {
+  const quest = getExplorationQuest('nonexistent_quest');
+  assert(quest === null, 'Should return null for invalid id');
+});
+
+test('getQuestsForRoom finds quests starting in center', () => {
+  const quests = getQuestsForRoom('center');
+  assert(quests.length >= 1, 'Should find at least 1 quest starting in center');
+  const ids = quests.map(q => q.id);
+  assert(ids.includes('explore_village'), 'explore_village starts in center');
+});
+
+test('getQuestLocations returns valid room IDs', () => {
+  const locations = getQuestLocations();
+  assert(locations.length >= 5, 'Should have multiple locations');
+  for (const loc of locations) {
+    assert(VALID_ROOM_IDS.includes(loc), `Invalid location: ${loc}`);
+  }
+});
+
+test('world_tour quest covers all 9 rooms', () => {
+  const tour = getExplorationQuest('world_tour');
+  const exploreObjs = tour.stages[0].objectives.filter(o => o.type === 'EXPLORE');
+  assert(exploreObjs.length === 9, 'World tour should visit all 9 rooms');
+  const visited = new Set(exploreObjs.map(o => o.locationId));
+  for (const roomId of VALID_ROOM_IDS) {
+    assert(visited.has(roomId), `World tour missing room: ${roomId}`);
+  }
+});
+
+console.log('\n=== Specific Quest Tests ===\n');
+
+test('explore_village is level 1 beginner quest', () => {
+  const quest = getExplorationQuest('explore_village');
+  assert(quest.level === 1);
+  assert(quest.type === 'SIDE');
+  assert(quest.prerequisites.length === 0, 'Should have no prerequisites');
+});
+
+test('marsh_mystery requires explore_village', () => {
+  const quest = getExplorationQuest('marsh_mystery');
+  assert(quest.prerequisites.includes('explore_village'));
+});
+
+test('dock_investigation has 3 stages', () => {
+  const quest = getExplorationQuest('dock_investigation');
+  assert(quest.stages.length === 3);
+  assert(quest.stages[0].id === 'reach_dock');
+  assert(quest.stages[1].id === 'gather_evidence');
+  assert(quest.stages[2].id === 'confront_smugglers');
+});
+
+test('ridge_expedition is MAIN quest type', () => {
+  const quest = getExplorationQuest('ridge_expedition');
+  assert(quest.type === 'MAIN');
+});
+
+test('grove_guardian has DELIVER objective', () => {
+  const quest = getExplorationQuest('grove_guardian');
+  const stage2 = quest.stages[1];
+  const deliverObj = stage2.objectives.find(o => o.type === 'DELIVER');
+  assert(deliverObj !== undefined, 'Should have DELIVER objective');
+  assert(deliverObj.itemId === 'forest_herb');
+});
+
+console.log('\n' + '='.repeat(50));
+console.log(`Results: ${passed} passed, ${failed} failed`);
+console.log('='.repeat(50) + '\n');
+
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## Summary
Expands the Story/Dialog module with exploration quests that use valid map room IDs.

## Content
- **6 new exploration quests** that tie into the existing 3x3 map system
- **17 passing tests** validating quest structure and helper functions

### Quests Added
| Quest ID | Name | Type | Level | Starting Location |
|----------|------|------|-------|-------------------|
| explore_village | Know Your Surroundings | SIDE | 1 | center |
| marsh_mystery | Whispers in the Marsh | SIDE | 2 | sw |
| grove_guardian | The Guardian of the Grove | SIDE | 3 | nw |
| ridge_expedition | The Northeast Ridge | MAIN | 3 | ne |
| dock_investigation | Trouble at the Docks | SIDE | 4 | se |
| world_tour | Explorer Extraordinaire | ACHIEVEMENT | 1 | all 9 rooms |

### Key Features
- All EXPLORE objectives use valid map room IDs: nw, n, ne, w, center, e, sw, s, se
- Helper functions: `getQuestsForRoom()`, `getQuestLocations()`
- Multiple objective types: EXPLORE, KILL, TALK, DELIVER, COLLECT
- Quest prerequisites chain (marsh_mystery requires explore_village)
- world_tour achievement visits all 9 regions

## Files Changed
- `src/data/exploration-quests.js` - 320 lines (quest definitions + helpers)
- `tests/exploration-quests-test.mjs` - 170 lines (17 tests)
- `package.json` - adds test:exploration script

## Testing
```
npm run test:exploration
# Results: 17 passed, 0 failed
```

## Easter Egg Scan
✅ **CLEAN** - Scanned for: egg, easter, rabbit, bunny, hunt, basket, 🥚, 🐰, 🐣, hidden.?egg, base64, atob, btoa, eval(, Function(, fromCharCode
- Only match: "Eastern Fields" (legitimate location name)

## Anti-Sabotage Checklist
- [x] No hidden egg/easter references
- [x] No obfuscation patterns
- [x] All location IDs match actual map room IDs
- [x] Quest structure follows existing conventions