### PR TITLE
feat: connect enemy loot tables to item generation system

### DIFF
--- a/src/game-integration.js
+++ b/src/game-integration.js
@@ -5,13 +5,14 @@ import { createCombatState, calculateTurnOrder, executePlayerAction, getAbilitie
 import { createCharacter, createParty, addMember, setActiveParty, getActiveMembers, gainXp, toCombatant } from './characters/index.js';
 import { createMap, movePlayer, getCurrentRoom, getRoomExits } from './map.js';
 import { useItem, getInventory, addItem, removeItem } from './items.js';
+import { lootTables, getRandomLoot } from './data/items.js';
 
 const RNG_MOD = 2147483647;
 const RNG_MULT = 48271;
 const ENEMY_POOL = [
-  { name: 'Slime', hp: 20, maxHp: 20, mp: 0, maxMp: 0, atk: 5, def: 3, spd: 4, abilities: ['slime-splash'], element: 'earth', xpReward: 15, goldReward: 8 },
-  { name: 'Goblin', hp: 30, maxHp: 30, mp: 5, maxMp: 5, atk: 8, def: 4, spd: 7, abilities: ['backstab'], element: 'physical', xpReward: 25, goldReward: 15 },
-  { name: 'Fire Imp', hp: 25, maxHp: 25, mp: 15, maxMp: 15, atk: 10, def: 3, spd: 6, abilities: ['fire-breath'], element: 'fire', xpReward: 30, goldReward: 20 },
+  { name: 'Slime', hp: 20, maxHp: 20, mp: 0, maxMp: 0, atk: 5, def: 3, spd: 4, abilities: ['slime-splash'], element: 'earth', lootTable: 'goblin', xpReward: 15, goldReward: 8 },
+  { name: 'Goblin', hp: 30, maxHp: 30, mp: 5, maxMp: 5, atk: 8, def: 4, spd: 7, abilities: ['backstab'], element: 'physical', lootTable: 'goblin', xpReward: 25, goldReward: 15 },
+  { name: 'Fire Imp', hp: 25, maxHp: 25, mp: 15, maxMp: 15, atk: 10, def: 3, spd: 6, abilities: ['fire-breath'], element: 'fire', lootTable: 'banditCaptain', xpReward: 30, goldReward: 20 },
 ];
 
 let hooksReady = false;
@@ -218,7 +219,21 @@ export function handleCombatAction(gameState, action) {
   let party = syncPartyFromCombat(updated.party, combatState);
   updated = { ...updated, combatState, party, inventory };
   if (combatState.phase === 'victory') {
-    const rewardResult = applyRewards(party, inventory, combatState.rewards);
+    const rewards = { ...(combatState.rewards ?? {}) };
+    const rewardItems = [...(rewards.items ?? [])];
+    combatState.allCombatants
+      .filter((combatant) => combatant.side === 'enemy')
+      .forEach((enemy) => {
+        const lootTableId = enemy.lootTable;
+        if (!lootTableId) return;
+        const lootTable = lootTables[lootTableId];
+        if (!lootTable) return;
+        const loot = getRandomLoot(lootTable.rarityWeights);
+        if (loot) rewardItems.push(loot.id);
+      });
+    rewards.items = rewardItems;
+    combatState = { ...combatState, rewards };
+    const rewardResult = applyRewards(party, inventory, rewards);
     messages.push(...rewardResult.messages);
     updated = { ...updated, party: rewardResult.party, inventory: rewardResult.inventory, combatState: null, gamePhase: setGameState(GameState.EXPLORATION) };
     emit('combat:win', { rewards: combatState.rewards });


### PR DESCRIPTION

## Description
Connects the enhanced item database's loot tables (from PR #21) to the game integration layer, enabling enemies to drop rarity‑weighted loot.

## Changes
1. **Added  property to  entries**:
   - Slime & Goblin →  table
   - Fire Imp →  table
2. **Imported loot‑generation utilities** from  (, )
3. **Enhanced victory phase in **:
   - Iterates over defeated enemies, looks up their loot table, calls  with the table's rarity weights
   - Collected item IDs appended to 
   - Preserves any existing  (backward compatibility)
   - Silent skip if enemy lacks a loot table or table is undefined
4. **All existing tests pass** (1,031+ tests) – no regressions.

## Integration Points
- Enemy definitions in  now carry a  ID
- Loot generation uses the same rarity‑weighted logic as chests/other sources defined in 
- Item drops are seamlessly added to the player's inventory via the existing reward‑application flow

## Easter‑Egg Scan
- No hidden , , , , or obfuscated strings
- Changes are purely functional, no sabotage

## Verification
- 
> ai-village-rpg-game@0.0.1 test:all
> node ./tests/ci-smoke.mjs && node ./tests/combat-test.mjs && node ./tests/character-test.mjs && node ./tests/items-test.mjs && node ./tests/map-test.mjs && node ./tests/enemies-test.mjs && node ./tests/story-test.mjs && node ./tests/engine-test.mjs && node ./tests/state-test.mjs && node ./tests/integration-test.mjs && npm run test:exploration-loop && node ./tests/combat-actions-test.mjs && npm run test:exploration && npm run test:input && npm run test:move-dispatch && npm run test:ui && npm run test:inventory-mgmt && npm run test:quest-integration && npm run test:inventory-wiring

[CI] Smoke test passed. Core entrypoint files are present.
[CI] Verified: 11 required files.

--- Damage Calculation ---
  ✅ Basic damage is at least 1 (got 4)
  ✅ Non-critical with rng 0.5
  ✅ Defending reduces damage (1 vs 4)
  ✅ Critical hit with rng > 0.9

--- Element System ---
  ✅ Fire vs Ice = 2.0x
  ✅ Fire vs Earth = 0.5x
  ✅ Light vs Light = immune
  ✅ Physical vs anything = neutral

--- Status Effects ---
  ✅ Created poison effect
  ✅ Poison type correct
  ✅ Poison duration is 3
  ✅ Poison power is 5
  ✅ Stunned combatant detected
  ✅ Non-stunned combatant not detected

--- Abilities ---
  ✅ Fireball exists
  ✅ Fireball is fire element
  ✅ Fireball costs 6 MP
  ✅ Warrior has 3 abilities
  ✅ Mage has 4 abilities

--- Combat State ---
  ✅ 3 combatants total (got 3)
  ✅ Phase is turn-calc (got turn-calc)
  ✅ 2 living allies
  ✅ 1 living enemy

--- Turn Calculation ---
  ✅ Active combatant set (ally-0)
  ✅ Turn is 1 (got 1)
  ✅ Fastest (Hero, spd 6) goes first (got Hero)
  ✅ Phase is choose-action for ally (got choose-action)

--- Player Attack ---
  ✅ Slime took damage (hp: 10)

========================================
Results: 28 passed, 0 failed
========================================

--- Stats ---
  PASS: Level 1 at XP 0
  PASS: Level 2 at XP 100
  PASS: Still level 1 at XP 99
  PASS: Level 20 at max XP
  PASS: Capped at level 20
  PASS: Need 100 XP for level 2
  PASS: No XP needed at max level

--- Classes ---
  PASS: Warrior class exists
  PASS: Warrior HP is 50
  PASS: Warrior has power-strike
  PASS: Mage MP is 50
  PASS: 4 classes available
  PASS: Unknown class returns null

--- Character Creation ---
  PASS: Custom ID respected
  PASS: Name set correctly
  PASS: Starts at level 1
  PASS: Starts with 0 XP
  PASS: Warrior HP is 50
  PASS: Starts with no equipment
  PASS: Auto-generated ID starts with char-

--- XP and Leveling ---
  PASS: XP is 100
  PASS: Reached level 2
  PASS: 1 level gained
  PASS: HP increased on level up
  PASS: Multi-level XP works

--- isAlive / healCharacter ---
  PASS: Full HP character is alive
  PASS: Zero HP character is dead
  PASS: Healed to 30 HP
  PASS: Capped at maxHp

--- toCombatant ---
  PASS: Combatant ID matches
  PASS: HP matches
  PASS: ATK matches
  PASS: Element is null
  PASS: xpReward formula correct

--- Party Management ---
  PASS: Party starts empty
  PASS: Added c1
  PASS: Added c2
  PASS: Duplicate add rejected
  PASS: Set active party
  PASS: 2 active members
  PASS: 2 combatants
  PASS: Rejects > MAX_PARTY_SIZE
  PASS: Roster down to 2
  PASS: p2 removed from active

--- XP Distribution ---
  PASS: 2 XP results
  PASS: p1 got 100 XP (split equally)

--- Restore Party ---
  PASS: HP restored to max
  PASS: MP restored to max

========================================
Results: 48 passed, 0 failed
========================================

--- Item Data ---
  ✅ Item catalog contains baseline items
  ✅ potion exists
  ✅ potion exposes required properties
  ✅ potion effect is an object
  ✅ potion stats is an object
  ✅ hiPotion exists
  ✅ hiPotion exposes required properties
  ✅ hiPotion effect is an object
  ✅ hiPotion stats is an object
  ✅ ether exists
  ✅ ether exposes required properties
  ✅ ether effect is an object
  ✅ ether stats is an object
  ✅ bomb exists
  ✅ bomb exposes required properties
  ✅ bomb effect is an object
  ✅ bomb stats is an object
  ✅ antidote exists
  ✅ antidote exposes required properties
  ✅ antidote effect is an object
  ✅ antidote stats is an object
  ✅ rustySword exists
  ✅ rustySword exposes required properties
  ✅ rustySword effect is an object
  ✅ rustySword stats is an object
  ✅ ironSword exists
  ✅ ironSword exposes required properties
  ✅ ironSword effect is an object
  ✅ ironSword stats is an object
  ✅ huntersBow exists
  ✅ huntersBow exposes required properties
  ✅ huntersBow effect is an object
  ✅ huntersBow stats is an object
  ✅ arcaneStaff exists
  ✅ arcaneStaff exposes required properties
  ✅ arcaneStaff effect is an object
  ✅ arcaneStaff stats is an object
  ✅ dragonSpear exists
  ✅ dragonSpear exposes required properties
  ✅ dragonSpear effect is an object
  ✅ dragonSpear stats is an object
  ✅ leatherArmor exists
  ✅ leatherArmor exposes required properties
  ✅ leatherArmor effect is an object
  ✅ leatherArmor stats is an object
  ✅ chainmail exists
  ✅ chainmail exposes required properties
  ✅ chainmail effect is an object
  ✅ chainmail stats is an object
  ✅ mageRobe exists
  ✅ mageRobe exposes required properties
  ✅ mageRobe effect is an object
  ✅ mageRobe stats is an object
  ✅ shadowCloak exists
  ✅ shadowCloak exposes required properties
  ✅ shadowCloak effect is an object
  ✅ shadowCloak stats is an object
  ✅ ringOfFortune exists
  ✅ ringOfFortune exposes required properties
  ✅ ringOfFortune effect is an object
  ✅ ringOfFortune stats is an object
  ✅ amuletOfVigor exists
  ✅ amuletOfVigor exposes required properties
  ✅ amuletOfVigor effect is an object
  ✅ amuletOfVigor stats is an object
  ✅ bootsOfSwiftness exists
  ✅ bootsOfSwiftness exposes required properties
  ✅ bootsOfSwiftness effect is an object
  ✅ bootsOfSwiftness stats is an object

--- Rarity Colors ---
  ✅ All rarity colors are defined

--- Loot Tables ---
  ✅ goblin loot table exists
  ✅ goblin has rarityWeights
  ✅ goblin defines weights for all rarities
  ✅ banditCaptain loot table exists
  ✅ banditCaptain has rarityWeights
  ✅ banditCaptain defines weights for all rarities
  ✅ forestChest loot table exists
  ✅ forestChest has rarityWeights
  ✅ forestChest defines weights for all rarities
  ✅ castleArmory loot table exists
  ✅ castleArmory has rarityWeights
  ✅ castleArmory defines weights for all rarities
  ✅ dragonHoard loot table exists
  ✅ dragonHoard has rarityWeights
  ✅ dragonHoard defines weights for all rarities

--- getRandomLoot ---
  ✅ Loot is returned for goblin table
  ✅ Weighted roll selects Common rarity at 0.3
  ✅ Deterministic selection returns second Common item (got antidote)
  ✅ Returns null when no weights provided

--- Inventory Utilities ---
  ✅ Add potion increments count
  ✅ Adding quantity stacks items
  ✅ Removing items decreases count
  ✅ Removal fails gracefully when insufficient quantity
  ✅ getItemCount returns current amount
  ✅ hasItem true when enough quantity
  ✅ hasItem false when missing item

--- useItem ---
  ✅ Potion use succeeds
  ✅ Potion heals 20 HP
  ✅ Potion healed amount reported
  ✅ Potion count reduced by 1
  ✅ Hi-Potion heals up to max HP
  ✅ Hi-Potion healing amount reported
  ✅ Hi-Potion consumed
  ✅ Ether restores MP up to max
  ✅ Ether restored MP amount reported
  ✅ Ether consumed
  ✅ Antidote cleanses poison
  ✅ Antidote consumed

--- Backward Compatibility ---
  ✅ Legacy heal property remains on potion

--- Inventory Normalization & Display ---
  ✅ Existing keyed inventory remains intact
  ✅ Legacy potion count normalized
  ✅ Null inventory normalizes to empty object
  ✅ Display shows item names and counts
  ✅ Display resolves known item names
  ✅ Display falls back to ID for unknown items

========================================
Results: 115 passed, 0 failed
========================================

--- World state creation ---
  PASS: Starts in default roomRow
  PASS: Starts in default roomCol
  PASS: Starts at default x
  PASS: Starts at default y

--- Persisted state validation ---
  PASS: Invalid room snaps to default state
  PASS: Blocked tile -> default x
  PASS: Blocked tile -> default y
  PASS: Clamps x into room bounds
  PASS: Clamps y into room bounds

--- Movement within room ---
  PASS: Cannot move into perimeter wall
  PASS: Wall collision reported
  PASS: State unchanged on blocked move
  PASS: Can move south into open tile
  PASS: Y increments on south move

--- Invalid direction ---
  PASS: Invalid direction does not move
  PASS: Invalid direction blocked reason

--- Room transitions ---
  PASS: Moved on north transition
  PASS: Transitioned to another room
  PASS: Room row decremented when moving north
  PASS: Room col unchanged when moving north
  PASS: X preserved across transition
  PASS: Y set to opposite edge on transition
  PASS: movePlayer returns current room object
  PASS: No move when transitioning past world edge
  PASS: Blocked reason is edge at world boundary
  PASS: No transition at world boundary

========================================
Results: 26 passed, 0 failed
========================================

--- getEnemy ---
  PASS: Goblin exists
  PASS: Goblin name correct
  PASS: Goblin HP correct
  PASS: Goblin has power-strike
  PASS: getEnemy returns a fresh copy
  PASS: Ability mutations do not persist
  PASS: Unknown enemy returns null

--- getEncounter ---
  PASS: Encounter returns an array
  PASS: Level 0 clamps to tier 1 (slime pick)
  PASS: Encounter arrays are independent copies
  PASS: String level 3 resolves to orc encounter
  PASS: Level 99 clamps to tier 5 (dragon pick)
  PASS: Random selection picks a valid tier 2 group

========================================
Results: 13 passed, 0 failed
========================================

--- Dialog Node Type Tests ---

✓ TEXT node has required properties
✓ CHOICE node has choices array
✓ CONDITIONAL node has conditions array
✓ ACTION node has actions array
✓ END node terminates dialog

--- Quest Structure Tests ---

✓ Quest has required fields
✓ Quest stage has objectives
✓ Quest objective types are valid
✓ Quest rewards structure is correct

--- NPC Structure Tests ---

✓ NPC has required fields
✓ NPC types are valid
✓ Merchant NPC has shop inventory
✓ Companion NPC has stats
✓ NPC personality values are in valid range

--- Dialog Flow Tests ---

✓ Dialog tree is navigable
✓ Dialog has reachable END node

--- Condition Tests ---

✓ Condition types are valid
✓ Action types are valid

--- Integration Tests ---

✓ Quest references valid NPC ids
✓ NPC references valid dialog id
✓ Kill objective tracks progress correctly
✓ Collect objective validates item count

22 passed, 0 failed

--- GameState Constants ---
  PASS: MENU state exists
  PASS: EXPLORATION state exists
  PASS: COMBAT state exists
  PASS: DIALOG state exists
  PASS: INVENTORY state exists
  PASS: GAME_OVER state exists
  PASS: GameState has 6 states

--- TurnPhase Constants ---
  PASS: PLAYER_SELECT phase exists
  PASS: PLAYER_ACTION phase exists
  PASS: ENEMY_TURN phase exists
  PASS: RESOLVE phase exists
  PASS: TurnPhase has 4 phases

--- Event System ---
  PASS: Event was received
  PASS: Event data is correct
  PASS: Event not received after off()
  PASS: Multiple listeners called
  PASS: Emit with no listeners does not throw

--- Game State Management ---
Game Engine initialized
  PASS: Starts in MENU state after init
  PASS: State changes to EXPLORATION
  PASS: State change event emitted
  PASS: Old state is MENU
  PASS: New state is EXPLORATION
  PASS: State changes to COMBAT

--- Save System ---
  PASS: Save returns true on success
  PASS: Load returns saved data
  PASS: Player name preserved
  PASS: Player hp preserved
  PASS: Turn preserved
  PASS: SavedAt timestamp added
  PASS: Save fails for negative slot
  PASS: Save fails for slot >= MAX_SAVE_SLOTS
  PASS: Load returns null for negative slot
  PASS: Load returns null for slot >= MAX_SAVE_SLOTS
  PASS: Load returns null for empty slot

--- Save Slots Info ---
  PASS: Returns all 5 slots
  PASS: Slot 0 exists
  PASS: Slot 0 has correct player name
  PASS: Slot 0 has correct turn
  PASS: Slot 1 does not exist
  PASS: Slot 2 exists
  PASS: Slot 2 has correct player name
  PASS: Slot 3 does not exist
  PASS: Slot 4 does not exist

--- Delete Save Slot ---
  PASS: Delete returns true
  PASS: Delete event emitted
  PASS: Delete event has correct slot index
  PASS: Slot is empty after delete
  PASS: Delete fails for invalid slot

--- Engine Init ---
Game Engine initialized
  PASS: initEngine returns true
  PASS: Init event emitted
  PASS: Init sets state to MENU

========================================
Results: 51 passed, 0 failed
========================================

--- initialState ---
  PASS: State has version 1
  PASS: State has numeric rngSeed
  PASS: Phase starts as player-turn
  PASS: Turn starts at 1
  PASS: Player exists
  PASS: Player has name
  PASS: Player has hp
  PASS: Player has maxHp
  PASS: Player hp <= maxHp
  PASS: Player has atk
  PASS: Player has def
  PASS: Player not defending initially
  PASS: Player has inventory
  PASS: Player has potions
  PASS: Enemy exists
  PASS: Enemy has name
  PASS: Enemy has hp
  PASS: Enemy has maxHp
  PASS: Enemy not defending initially
  PASS: Log is array
  PASS: Log has initial entries
  PASS: World state exists

--- initialStateWithClass ---
  PASS: Warrior has correct classId
  PASS: Warrior has correct name
  PASS: Player starts at level 1
  PASS: Player starts with 0 xp
  PASS: Player has mp stat
  PASS: World state exists for class-based init
  PASS: Mage has correct classId
  PASS: Mage has correct name
  PASS: Rogue has correct classId
  PASS: Rogue has correct name
  PASS: Cleric has correct classId
  PASS: Cleric has correct name
  PASS: Error mentions unknown classId
  PASS: Unknown class throws error

--- clamp ---
  PASS: Value in range unchanged
  PASS: Value below range clamped to min
  PASS: Value above range clamped to max
  PASS: Value at min unchanged
  PASS: Value at max unchanged
  PASS: Single value range works
  PASS: Negative range works

--- pushLog ---
  PASS: Log length increased
  PASS: New line added at end
  PASS: Original state unchanged (immutable)
  PASS: Log capped at 200 lines
  PASS: New line at end after truncation
  PASS: Oldest line dropped was first

--- saveToLocalStorage / loadFromLocalStorage ---
  PASS: Loaded state is not null
  PASS: Player name preserved
  PASS: Player hp preserved
  PASS: Turn preserved
  PASS: Empty storage returns null
  PASS: Invalid JSON returns null
  PASS: Non-object JSON returns null
  PASS: Null JSON returns null

========================================
Results: 57 passed, 0 failed
========================================

--- startNewGame ---
Game Engine initialized
  ✅ startNewGame returns an object
  ✅ gamePhase is EXPLORATION (got exploration)
  ✅ party exists
  ✅ party.members is an array
  ✅ party has 4 members (got 4)
  ✅ party members are Hero, Sage, Shadow, Healer
  ✅ classes are warrior, mage, rogue, cleric
  ✅ 4 active party members (got 4)
  ✅ active party IDs match
  ✅ map exists
  ✅ map has worldData
  ✅ map has worldState
  ✅ combatState starts null
  ✅ turnCount starts at 0 (got 0)
  ✅ messages is an array
  ✅ messages include opening text
  ✅ rngSeed is a number (got number)
  ✅ rngSeed is positive
  ✅ inventory is an object
  ✅ inventory has 2 potions (got 2)
  ✅ Hero has hp > 0 (50)
  ✅ Hero has maxHp > 0
  ✅ Hero has numeric atk
  ✅ Hero has numeric def
  ✅ Hero has numeric spd
  ✅ Hero starts at level 1
  ✅ Hero starts with 0 xp
  ✅ Hero has abilities array
  ✅ Sage has hp > 0 (28)
  ✅ Sage has maxHp > 0
  ✅ Sage has numeric atk
  ✅ Sage has numeric def
  ✅ Sage has numeric spd
  ✅ Sage starts at level 1
  ✅ Sage starts with 0 xp
  ✅ Sage has abilities array
  ✅ Shadow has hp > 0 (36)
  ✅ Shadow has maxHp > 0
  ✅ Shadow has numeric atk
  ✅ Shadow has numeric def
  ✅ Shadow has numeric spd
  ✅ Shadow starts at level 1
  ✅ Shadow starts with 0 xp
  ✅ Shadow has abilities array
  ✅ Healer has hp > 0 (40)
  ✅ Healer has maxHp > 0
  ✅ Healer has numeric atk
  ✅ Healer has numeric def
  ✅ Healer has numeric spd
  ✅ Healer starts at level 1
  ✅ Healer starts with 0 xp
  ✅ Healer has abilities array

--- getGameStatus ---
  ✅ status phase is exploration (got exploration)
  ✅ partyStatus is an array
  ✅ partyStatus has 4 entries (got 4)
  ✅ partyStatus entry has name (Hero)
  ✅ Hero has numeric hp
  ✅ Hero has numeric maxHp
  ✅ Hero has numeric level
  ✅ Hero has className (Warrior)
  ✅ partyStatus entry has name (Sage)
  ✅ Sage has numeric hp
  ✅ Sage has numeric maxHp
  ✅ Sage has numeric level
  ✅ Sage has className (Mage)
  ✅ partyStatus entry has name (Shadow)
  ✅ Shadow has numeric hp
  ✅ Shadow has numeric maxHp
  ✅ Shadow has numeric level
  ✅ Shadow has className (Rogue)
  ✅ partyStatus entry has name (Healer)
  ✅ Healer has numeric hp
  ✅ Healer has numeric maxHp
  ✅ Healer has numeric level
  ✅ Healer has className (Cleric)
  ✅ currentRoom is an object
  ✅ currentRoom has a name (Village Square)
  ✅ currentRoom has exits array
  ✅ currentRoom has at least 1 exit (got 4)
  ✅ turnCount is 0 (got 0)
  ✅ inventoryCount is a number (got 2)
  ✅ inventoryCount is 2 (got 2)

--- handleExplore (safe movement) ---
  ✅ have exits to try: north, south, west, east
  ✅ successfully moved in at least one direction
  ✅ turnCount incremented to 1 (got 1)
  ✅ new messages after explore

--- handleExplore (blocked movement) ---
  ✅ turnCount incremented even on blocked (got 1)
  ✅ blocked message present

--- handleExplore (wrong phase) ---
  ✅ returns same state when not in EXPLORATION
  ✅ turnCount unchanged when wrong phase

--- handleExplore (random encounter) ---
  ✅ found a seed that triggers a random encounter
  ✅ phase switched to COMBAT (got combat)
  ✅ combatState is set after encounter
  ✅ combatState has allCombatants
  ✅ 4 ally combatants (got 4)
  ✅ 1-3 enemies (got 1)
  ✅ enemy Goblin is from the pool
  ✅ enemy Goblin has hp > 0
  ✅ enemy Goblin has xpReward
  ✅ encounter message present

--- handleCombatAction ---
  ✅ combat phase is choose-action (got choose-action)
  ✅ active combatant found (ally-2)
  ✅ turnCount incremented after combat action
  ✅ combat progressed
  ✅ handleCombatAction returns same state when not in COMBAT

--- handleCombatAction (defend) ---
  ✅ turnCount incremented on defend
  ✅ state changed after defend

--- handleCombatAction (flee) ---
  ✅ turnCount incremented on flee

--- Full combat to victory ---
Game Engine initialized
  ✅ phase returned to EXPLORATION after victory (got exploration)
  ✅ combatState cleared after victory
  ✅ gold reward handled
  ✅ party gained XP after victory (total: 12)
  ✅ combat resolved in under 20 turns (took 1)

--- handleSave / handleLoad ---
Game Engine initialized
  ✅ handleSave returns true for valid slot
  ✅ handleSave returns true for slot 1
  ✅ handleSave returns false for invalid slot 99
  ✅ handleLoad returns non-null for occupied slot
  ✅ loaded party has 4 members (got 4)
  ✅ loaded turnCount is 0 (got 0)
  ✅ loaded inventory has 2 potions (got 2)
  ✅ handleLoad returns null for empty slot
  ✅ handleLoad returns null for invalid slot
  ✅ loaded party member names match

--- State isolation ---
Game Engine initialized
Game Engine initialized
  ✅ two startNewGame calls produce different objects
  ✅ rng seeds may differ (time-based)
  ✅ game2 turnCount unchanged after exploring game1

--- Edge cases ---
  ✅ getGameStatus works with minimal state
  ✅ empty party returns empty partyStatus
  ✅ empty inventory returns count 0
  ✅ explore with null direction still increments turn

==================================================
Integration tests: 130 passed, 0 failed, 130 total

> ai-village-rpg-game@0.0.1 test:exploration-loop
> node tests/exploration-loop-test.mjs


--- Initial State ---
  ✅ warrior: player exists
  ✅ warrior: player has HP
  ✅ warrior: player has maxHp
  ✅ warrior: player has ATK
  ✅ warrior: player has DEF
  ✅ warrior: enemy exists
  ✅ warrior: world state exists
  ✅ warrior: world has roomRow
  ✅ warrior: world has roomCol
  ✅ mage: player exists
  ✅ mage: player has HP
  ✅ mage: player has maxHp
  ✅ mage: player has ATK
  ✅ mage: player has DEF
  ✅ mage: enemy exists
  ✅ mage: world state exists
  ✅ mage: world has roomRow
  ✅ mage: world has roomCol
  ✅ rogue: player exists
  ✅ rogue: player has HP
  ✅ rogue: player has maxHp
  ✅ rogue: player has ATK
  ✅ rogue: player has DEF
  ✅ rogue: enemy exists
  ✅ rogue: world state exists
  ✅ rogue: world has roomRow
  ✅ rogue: world has roomCol
  ✅ cleric: player exists
  ✅ cleric: player has HP
  ✅ cleric: player has maxHp
  ✅ cleric: player has ATK
  ✅ cleric: player has DEF
  ✅ cleric: enemy exists
  ✅ cleric: world state exists
  ✅ cleric: world has roomRow
  ✅ cleric: world has roomCol

--- Exploration Phase Setup ---
  ✅ phase set to exploration after class select
  ✅ player has name
  ✅ player classId is warrior
  ✅ player starts at level 1
  ✅ player starts with 0 XP
  ✅ player starts with 3 potions

--- Movement ---
  ✅ movePlayer returns result
  ✅ result has moved property
  ✅ result has worldState
  ✅ movePlayer(north) returns result
  ✅ movePlayer(north) has moved boolean
  ✅ movePlayer(south) returns result
  ✅ movePlayer(south) has moved boolean
  ✅ movePlayer(west) returns result
  ✅ movePlayer(west) has moved boolean
  ✅ movePlayer(east) returns result
  ✅ movePlayer(east) has moved boolean

--- Invalid Directions ---
  ✅ up is not a valid direction
  ✅ invalid direction rejected
  ✅ empty string direction rejected

--- Room Info ---
  ✅ getCurrentRoom returns room
  ✅ room has name
  ✅ starting room is Village Square
  ✅ getRoomExits returns array
  ✅ center room has exits
  ✅ center has north exit
  ✅ center has south exit
  ✅ center has west exit
  ✅ center has east exit

--- Room Transitions ---
  ✅ room transition detected when moving north repeatedly
  ✅ new room exists after transition
  ✅ moved to different room

--- Encounter RNG ---
  ✅ nextRng returns numeric seed
  ✅ nextRng returns numeric value
  ✅ RNG value in [0, 1)
  ✅ RNG seed advances
  ✅ consecutive RNG values differ

--- Start New Encounter ---
  ✅ encounter starts in player-turn phase
  ✅ encounter has enemy
  ✅ enemy has HP
  ✅ enemy has name
  ✅ encounter starts at turn 1

--- Full Combat Loop ---
  ✅ combat begins at player-turn
  ✅ combat resolved in under 50 turns (took 2)
  ✅ enemy defeated
  ✅ player survived
  ✅ can transition to exploration after victory
  ✅ player HP preserved after victory

--- Multi-Encounter Loop ---
  ✅ encounter 1 starts
  ✅ encounter 2 starts
  ✅ encounter 3 starts
  ✅ won at least 1 out of 3 encounters (won 3)

--- Defeat Flow ---
  ✅ defeat phase reached when HP drops to 0
  ✅ player HP at 0 or below
  ✅ try again returns to class-select

--- Inventory View ---
  ✅ player has inventory
  ✅ starts with 3 potions
  ✅ inventory message includes potion
  ✅ inventory message includes potion count

--- Save/Load with Exploration State ---
  ✅ loaded phase is exploration
  ✅ loaded world roomRow matches
  ✅ loaded world roomCol matches
  ✅ loaded world x matches
  ✅ loaded world y matches
  ✅ loaded player class matches

--- Log During Exploration ---
  ✅ log has 2 entries
  ✅ latest log entry correct
  ✅ log capped at 200 entries

==========================================
Exploration loop tests: 104 passed, 0 failed, 104 total

--- nextRng (Park-Miller LCG) ---
  PASS: nextRng returns seed number
  PASS: nextRng returns value number
  PASS: value is in [0, 1) range
  PASS: seed changes after nextRng
  PASS: nextRng is deterministic (seed)
  PASS: nextRng is deterministic (value)
  PASS: sequence produces different seeds
  PASS: sequence continues producing different seeds

--- startNewEncounter ---
  PASS: phase resets to player-turn
  PASS: turn resets to 1
  PASS: player defending resets
  PASS: enemy is set
  PASS: enemy has positive HP
  PASS: enemy HP equals maxHp
  PASS: enemy defending is false
  PASS: log has new entries
  PASS: player hp preserved
  PASS: player inventory preserved

--- playerAttack ---
  PASS: enemy took damage
  PASS: phase changes to enemy-turn
  PASS: player defending reset after attack
  PASS: log has attack message
  PASS: no damage on wrong phase
  PASS: phase unchanged on wrong phase

--- playerAttack vs defending enemy ---
  PASS: defending reduces damage taken
  PASS: enemy defending resets after being attacked

--- playerAttack leading to victory ---
  PASS: enemy HP clamped to 0
  PASS: phase is victory
  PASS: xp reward granted
  PASS: gold reward granted

--- playerDefend ---
  PASS: player is now defending
  PASS: phase changes to enemy-turn
  PASS: log has defend message
  PASS: defend ignored on wrong phase

--- playerUsePotion ---
  PASS: player healed
  PASS: HP does not exceed maxHp
  PASS: potion count decreased
  PASS: phase changes to enemy-turn
  PASS: defending reset after using potion
  PASS: log has potion message

--- playerUsePotion at full HP ---
  PASS: HP clamped at maxHp
  PASS: potion still consumed

--- playerUsePotion with no potions ---
  PASS: HP unchanged with no potions
  PASS: phase unchanged (no action taken)
  PASS: log has no-potion message

--- enemyAct (attack) ---
  PASS: RNG seed advanced
  PASS: phase is player-turn or defeat
  PASS: turn incremented or same
  PASS: log has enemy action message

--- enemyAct (defend - find a seed that triggers it) ---
  PASS: enemy is defending
  PASS: phase is player-turn after enemy defend
  PASS: player defending reset
  PASS: turn incremented

--- enemyAct wrong phase ---
  PASS: RNG seed unchanged on wrong phase
  PASS: player HP unchanged

--- enemyAct leading to defeat ---
  PASS: player HP clamped to 0
  PASS: phase is defeat

--- enemyAct with player defending ---
  PASS: defending reduces damage from enemy

========================================
Results: 58 passed, 0 failed
========================================

> ai-village-rpg-game@0.0.1 test:exploration
> node ./tests/exploration-quests-test.mjs


=== Exploration Quest Structure Tests ===

  ✅ EXPLORATION_QUESTS is defined and has quests
  ✅ All quests have required fields
  ✅ All quest stages have valid structure
  ✅ EXPLORE objectives use valid map room IDs
  ✅ Quest types are valid
  ✅ Rewards have proper structure

=== Helper Function Tests ===

  ✅ getExplorationQuests returns all quests
  ✅ getExplorationQuest returns correct quest
  ✅ getExplorationQuest returns null for invalid id
  ✅ getQuestsForRoom finds quests starting in center
  ✅ getQuestLocations returns valid room IDs
  ✅ world_tour quest covers all 9 rooms

=== Specific Quest Tests ===

  ✅ explore_village is level 1 beginner quest
  ✅ marsh_mystery requires explore_village
  ✅ dock_investigation has 3 stages
  ✅ ridge_expedition is MAIN quest type
  ✅ grove_guardian has DELIVER objective

==================================================
Results: 17 passed, 0 failed
==================================================


> ai-village-rpg-game@0.0.1 test:input
> node ./tests/input-test.mjs


--- keyToCardinalDirection ---
  PASS: 'w' => north
  PASS: 'W' => north
  PASS: 'ArrowUp' => north
  PASS: 's' => south
  PASS: 'S' => south
  PASS: 'ArrowDown' => south
  PASS: 'a' => west
  PASS: 'A' => west
  PASS: 'ArrowLeft' => west
  PASS: 'd' => east
  PASS: 'D' => east
  PASS: 'ArrowRight' => east

--- Unknown / invalid keys ---
  PASS: space => null
  PASS: Enter => null
  PASS: 'up' => null (avoid non-cardinal strings)
  PASS: 'north' => null (expects event.key)
  PASS: null => null
  PASS: undefined => null
  PASS: object => null

========================================
Results: 19 passed, 0 failed
========================================

> ai-village-rpg-game@0.0.1 test:move-dispatch
> node ./tests/move-dispatch-test.mjs


createWorldState() returns valid world state
  ✓ returns non-null
  ✓ has roomRow
  ✓ has roomCol
  ✓ has x
  ✓ has y
  ✓ starts at center row
  ✓ starts at center col

MOVE with valid direction updates world state
  ✓ returns result object
  ✓ result has moved
  ✓ result has worldState
  ✓ result has room
  ✓ moved is boolean

MOVE with invalid direction returns moved=false
  ✓ invalid direction: moved=false
  ✓ blocked is invalid-direction

MOVE state update pattern: spread world state correctly
  ✓ log gains a new entry
  ✓ phase unchanged
  ✓ world state preserved
  ✓ world updated to new world state

EXPLORE phase guard: MOVE only works in exploration phase
  ✓ MOVE is guarded to exploration phase only

EXPLORE phase guard: MOVE blocked in enemy-turn
  ✓ MOVE blocked during enemy-turn

EXPLORE phase guard: MOVE blocked in victory
  ✓ MOVE blocked in victory phase

EXPLORE transition: allowed from victory or defeat
  ✓ EXPLORE allowed from victory
  ✓ EXPLORE allowed from defeat
  ✓ EXPLORE blocked from player-turn
  ✓ EXPLORE blocked from enemy-turn

Valid directions for MOVE action
  ✓ 'north' is a valid direction
  ✓ 'south' is a valid direction
  ✓ 'east' is a valid direction
  ✓ 'west' is a valid direction
  ✓ 'up' is correctly rejected
  ✓ 'down' is correctly rejected
  ✓ 'left' is correctly rejected
  ✓ 'right' is correctly rejected
  ✓ '' is correctly rejected
  ✓ 'null' is correctly rejected
  ✓ 'undefined' is correctly rejected
  ✓ 'n' is correctly rejected
  ✓ 's' is correctly rejected
  ✓ 'e' is correctly rejected
  ✓ 'w' is correctly rejected

getRoomExits returns valid cardinal directions
  ✓ exits is an array
  ✓ exit 'north' is a cardinal direction
  ✓ exit 'south' is a cardinal direction
  ✓ exit 'west' is a cardinal direction
  ✓ exit 'east' is a cardinal direction
  ✓ center room has 4 exits

Corner rooms have only 2 exits
  ✓ NW corner has 2 exits
  ✓ NW has south exit
  ✓ NW has east exit

Edge rooms have 3 exits
  ✓ north edge room has 3 exits
  ✓ north edge room has no north exit

movePlayer transitions between rooms correctly
  ✓ starts at center
  ✓ transitioned to east room (col 2)
  ✓ has room info after transition
  ✓ can transition east from center room

movePlayer blocked at world edge
  ✓ NW corner blocks north movement at world edge

pushLog adds message to state log
  ✓ log grows by 1
  ✓ new entry appended at end
  ✓ other state properties preserved

pushLog caps log at 200 entries
  ✓ log capped at 200
  ✓ newest entry at end

──────────────────────────────────────────────────
Results: 61 passed, 0 failed

> ai-village-rpg-game@0.0.1 test:ui
> node ./tests/ui-test.mjs


Test: Renderer initialization
  ✓ Canvas element retrieved
  ✓ Context initialized

Test: clear() method
  ✓ clear() calls fillRect

Test: renderGame() with exploration phase
  ✓ Exploration renders shapes
  ✓ Exploration renders text

Test: renderGame() with battle phase
  ✓ Battle renders shapes
  ✓ Battle renders text

Test: renderMap() with valid world
  ✓ renderMap() draws rooms
  ✓ renderMap() draws player

Test: renderHUD() with party data
  ✓ HUD renders text
  ✓ HUD renders health bars

Test: renderBattle() with enemies
  ✓ Battle renders names
  ✓ Battle renders health bars

Test: renderBattleUI() with action buttons
  ✓ Battle UI renders buttons

==================================================
UI/Renderer Tests: 14 passed, 0 failed
==================================================


> ai-village-rpg-game@0.0.1 test:inventory-mgmt
> node ./tests/inventory-management-test.mjs

--- getEquipSlot ---
--- isEquippable ---
--- isUsable ---
--- getItemDetails ---
--- ensureEquipment ---
--- getEquipmentBonuses ---
--- equipItem ---
--- unequipItem ---
--- useConsumable ---
--- getCategorizedInventory ---
--- getEquipmentDisplay ---
--- createInventoryState ---
--- handleInventoryAction: CLOSE_INVENTORY ---
--- handleInventoryAction: INVENTORY_USE ---
--- handleInventoryAction: INVENTORY_EQUIP ---
--- handleInventoryAction: INVENTORY_UNEQUIP ---
--- handleInventoryAction: INVENTORY_VIEW_DETAILS ---
--- handleInventoryAction: INVENTORY_BACK ---
--- handleInventoryAction: unknown ---
--- Complex: full workflow ---
--- Edge cases ---
--- EQUIPMENT_SLOTS ---

=== Inventory Management Tests: 168 passed, 0 failed ===

> ai-village-rpg-game@0.0.1 test:quest-integration
> node ./tests/quest-integration-test.mjs


--- initQuestState ---
  ✅ activeQuests is array
  ✅ activeQuests starts empty
  ✅ completedQuests is array
  ✅ completedQuests starts empty
  ✅ questProgress is object
  ✅ discoveredRooms is array
  ✅ discoveredRooms starts empty

--- acceptQuest ---
  ✅ can accept valid quest
  ✅ quest added to activeQuests
  ✅ progress entry created
  ✅ acceptance message returned
  ✅ cannot accept quest already active
  ✅ already active message
  ✅ cannot accept non-existent quest
  ✅ not found message
  ✅ cannot accept quest without prerequisite
  ✅ prerequisite message

--- onRoomEnter - EXPLORE objectives ---
  ✅ messages returned on objective complete
  ✅ one objective completed
  ✅ visit_center objective completed
  ✅ center added to discovered rooms
  ✅ stage advanced to explore_paths
  ✅ north objective completed
  ✅ n added to discovered rooms
  ✅ quest completed
  ✅ explore_village completed
  ✅ quest in completedQuests
  ✅ quest removed from activeQuests

--- onRoomEnter - room discovery ---
  ✅ nw discovered
  ✅ nw not duplicated
  ✅ se discovered
  ✅ nw still there

--- onRoomEnter - no active quest ---
  ✅ no messages when no quest active
  ✅ no objectives completed
  ✅ room still tracked for discovery

--- onRoomEnter - edge cases ---
  ✅ null roomId returns empty messages
  ✅ undefined roomId returns empty messages

--- onEnemyKill - KILL objectives ---
  ✅ marsh_mystery accepted after completing prerequisite
  ✅ explore stage completed
  ✅ kill progress message returned
  ✅ wisp kill count incremented
  ✅ objective completed after 3 kills
  ✅ quest completed

--- onEnemyKill - edge cases ---
  ✅ null enemyType returns empty
  ✅ no active quest with slime objective

--- getQuestProgress ---
  ✅ null for unstarted quest
  ✅ progress exists for active quest
  ✅ isActive is true
  ✅ isComplete is false
  ✅ stageIndex starts at 0
  ✅ questName is correct

--- getAvailableQuestsInRoom ---
  ✅ center has available quests
  ✅ explore_village available in center
  ✅ explore_village not available after accepting

--- getActiveQuestsSummary ---
  ✅ no active quests initially
  ✅ two active quests
  ✅ explore_village in summary
  ✅ world_tour in summary

--- applyQuestRewards ---
  ✅ xp added
  ✅ gold added
  ✅ health_potion added
  ✅ explorers_badge added
  ✅ four reward messages

--- applyQuestRewards - edge cases ---
  ✅ gold unchanged with null rewards
  ✅ no messages for empty rewards

--- Full Quest Flow ---
  ✅ quest accepted
  ✅ first stage completed
  ✅ quest completed
  ✅ rewards returned
  ✅ xp reward applied (explore_village gives 25)
  ✅ gold reward applied (explore_village gives 10)

========================================
Quest Integration Tests: 71 passed, 0 failed
========================================

> ai-village-rpg-game@0.0.1 test:inventory-wiring
> node ./tests/inventory-wiring-test.mjs


--- createInventoryState ---
  ✅ creates state with main screen
  ✅ stores returnPhase
  ✅ defaults returnPhase to exploration
  ✅ selectedItem starts null
  ✅ message starts null

--- VIEW_INVENTORY dispatch simulation ---
  ✅ VIEW_INVENTORY transitions to inventory phase
  ✅ inventoryState.returnPhase is prior phase
  ✅ player is preserved on inventory open

--- CLOSE_INVENTORY ---
  ✅ CLOSE_INVENTORY returns to returnPhase
  ✅ CLOSE_INVENTORY removes inventoryState
  ✅ CLOSE_INVENTORY logs message
  ✅ CLOSE_INVENTORY from victory returns to victory

--- INVENTORY_BACK ---
  ✅ INVENTORY_BACK resets to main screen
  ✅ INVENTORY_BACK clears selectedItem
  ✅ INVENTORY_BACK clears message

--- INVENTORY_VIEW_DETAILS ---
  ✅ INVENTORY_VIEW_DETAILS sets details screen
  ✅ INVENTORY_VIEW_DETAILS sets selectedItem

--- INVENTORY_USE ---
  ✅ INVENTORY_USE on consumable updates player HP
  ✅ INVENTORY_USE on non-usable item returns error message

--- getCategorizedInventory ---
  ✅ consumables include potion
  ✅ empty inventory returns empty categories
  ✅ filters out zero-count items

--- getItemDetails ---
  ✅ returns null for unknown item
  ✅ potion details has name
  ✅ potion is usable
  ✅ potion is not equippable

--- no-op for unknown inventory action ---
  ✅ unknown action returns unchanged state

--- Easter egg scan ---
  ✅ src/main.js has no egg/easter keywords
  ✅ src/render.js has no egg/easter keywords

==========================================
Inventory wiring tests: 29 passed, 0 failed, 29 total passes (1,031+ tests)
- Manual test: defeat enemies and verify items appear in inventory
- Backward compatible: existing hard‑coded  still work
- Safety checks guard against missing loot tables

## Related PRs
- PR #21 (enhanced item database with loot tables)
- PR #7 (items utility module)

## Module Assignment
This PR completes the **Items/Equipment** module assignment (DeepSeek‑V3.2).
