### PR TITLE
fix: Integrate audio settings with SFX system

### DIFF
--- a/src/audio-system.js
+++ b/src/audio-system.js
@@ -1,0 +1,48 @@
+import { createSfx } from './audio/sfx.js';
+import { loadSettings } from './settings.js';
+
+let sfxInstance = null;
+
+export function getSfx() {
+  if (!sfxInstance) {
+    const settings = loadSettings();
+    sfxInstance = createSfx({
+      masterVolume: settings.audio?.masterVolume ?? 0.7,
+      muted: settings.audio?.muted ?? false,
+      categories: {
+        ui: settings.audio?.sfxVolume ?? 1.0,
+        map: settings.audio?.sfxVolume ?? 1.0,
+        combat: settings.audio?.sfxVolume ?? 1.0,
+        // Music is handled separately or we could add a music category if sfx supported it
+      }
+    });
+  }
+  return sfxInstance;
+}
+
+export async function initAudio() {
+  const sfx = getSfx();
+  await sfx.init();
+  return sfx;
+}
+
+export function updateAudioSettings(settings) {
+  const sfx = getSfx();
+  if (!sfx) return;
+
+  if (settings.audio) {
+    if (typeof settings.audio.masterVolume === 'number') {
+      sfx.setMasterVolume(settings.audio.masterVolume);
+    }
+    if (typeof settings.audio.muted === 'boolean') {
+      sfx.mute(settings.audio.muted);
+    }
+    if (typeof settings.audio.sfxVolume === 'number') {
+      // Apply sfx volume to all non-music categories
+      const val = settings.audio.sfxVolume;
+      sfx.setCategoryVolume('ui', val);
+      sfx.setCategoryVolume('map', val);
+      sfx.setCategoryVolume('combat', val);
+    }
+  }
+}

--- a/src/handlers/ui-handler.js
+++ b/src/handlers/ui-handler.js
@@ -1,3 +1,4 @@
+import { updateAudioSettings } from '../audio-system.js';
 import { createInventoryState, handleInventoryAction } from '../inventory.js';
 import { createLevelUpState, advanceLevelUp } from '../level-up.js';
 import { acceptQuest } from '../quest-integration.js';
@@ -31,12 +32,14 @@ export function handleUIAction(state, action) {
     if (state.phase !== 'settings') return null;
     const newSettings = updateSetting(state.settings || {}, action.path, action.value);
     saveSettings(newSettings);
+    updateAudioSettings(newSettings);
     return { ...state, settings: newSettings };
   }
 
   if (type === 'RESET_SETTINGS') {
     if (state.phase !== 'settings') return null;
     const newSettings = resetSettings();
+    updateAudioSettings(newSettings);
     return pushLog({ ...state, settings: newSettings }, 'Settings reset to defaults.');
   }
 

--- a/src/main.js
+++ b/src/main.js
@@ -5,8 +5,23 @@ import { handleExplorationAction } from './handlers/exploration-handler.js';
 import { handleSystemAction } from './handlers/system-handler.js';
 import { handleUIAction } from './handlers/ui-handler.js';
 import { handleStateTransitions } from './state-transitions.js';
+import { initAudio } from './audio-system.js';
 
 let state = { phase: 'class-select', log: ['Welcome to AI Village RPG! Select your class.'] };
+
+// Initialize audio system on first interaction
+const startAudio = async () => {
+  try {
+    await initAudio();
+    // Remove listener after success
+    window.removeEventListener('click', startAudio);
+    window.removeEventListener('keydown', startAudio);
+  } catch (e) {
+    console.warn('Audio init failed (likely autoplay policy):', e);
+  }
+};
+window.addEventListener('click', startAudio, { once: true });
+window.addEventListener('keydown', startAudio, { once: true });
 
 function setState(next) {
   // Apply automatic state transitions (Level Up, Battle Summary)


### PR DESCRIPTION
This PR fixes a bug where audio settings (master volume, sfx volume, muted) were not applied to the SFX system.

Changes:
- Created `src/audio-system.js` to manage the SFX singleton and handle updates.
- Updated `src/main.js` to initialize the audio system on user interaction.
- Updated `src/handlers/ui-handler.js` to call `updateAudioSettings` when settings are changed via `UPDATE_SETTING` or `RESET_SETTINGS`.

Validation:
- Manually tested that updating settings now calls the audio system update function.
- Verified no circular dependencies or syntax errors.
- Verified that `tests/settings-test.mjs` still passes (since it tests logic, not side effects).
- Created a test case (deleted before commit) that confirmed direct volume updates work.