### PR TITLE
Quest & NPC integrity tests + content/whitespace guards

### DIFF
--- a/docs/main-dispatch-refactor-plan-gpt-5-1.md
+++ b/docs/main-dispatch-refactor-plan-gpt-5-1.md
@@ -1,0 +1,339 @@
+# `src/main.js` Dispatch & State Controller Refactor Plan (GPT-5.1)
+
+_Last updated: Day 339 – GPT-5.1_
+
+## 1. Goals & Constraints
+
+**Goals**
+
+- Make `src/main.js` easier to reason about by:
+  - Extracting self-contained helpers for complex action flows.
+  - Reducing duplication (e.g., room/quest/minimap updates across `EXPLORE` and `MOVE`).
+  - Keeping all logic testable and observable.
+- Preserve the existing single-hero flow and state shape.
+- Preserve `gameStats` wiring semantics introduced in PR #65 / #69.
+- Keep behavior 100% backward-compatible at the observable level (tests + player experience).
+
+**Non-goals (explicitly out of scope for this refactor)**
+
+- Do **not** integrate `startNewGame()` from `src/game-integration.js` into `main.js`.
+  - `startNewGame()` builds a fixed 4-member party and a different state shape.
+  - `main.js` expects a single player created via `initialStateWithClass(classId)`.
+- Do **not** alter global state structure, phases, or DOM wiring.
+- Do **not** change how quests, minimap, dialog, inventory, or engine saves behave.
+- Do **not** introduce new dependencies, obfuscation, or any holiday/easter motifs.
+
+**Hard constraints / invariants**
+
+- `node --check src/main.js` must pass before and after the refactor.
+- `npm run test:all:quiet` (and `npm run test:shop`) must pass.
+- Policy tests for holiday/egg words and obfuscation must remain green.
+- No `package-lock.json` is added or modified.
+- No changes to public module APIs imported by tests (e.g., `state.js`, `combat.js`, `map.js`, `quest-integration.js`).
+
+Key tests that implicitly define behavior for `main.js` and must stay green:
+
+- `tests/state-test.mjs`
+- `tests/integration-test.mjs`
+- `tests/exploration-loop-test.mjs`
+- `tests/move-dispatch-test.mjs`
+- `tests/quest-log-ui-test.mjs`
+- `tests/inventory-wiring-test.mjs`
+- `tests/npc-dialog-test.mjs`
+- `tests/level-up-test.mjs`
+- `tests/game-stats-wiring-test.mjs`
+- `tests/minimap-test.mjs`
+
+
+## 2. Current Structure Overview (Day 339)
+
+**Top-level state & helpers**
+
+- `state` is a mutable module-level object initialized with `phase: 'class-select'` and a welcome log line.
+- `setState(next)`:
+  - Detects level-ups when entering `victory` and converts them into `pendingLevelUps` using `checkLevelUps`.
+  - Immediately wraps `victory` into `battle-summary` via `createBattleSummary(next)`.
+  - Assigns `state = next` and calls `render(state, dispatch)`.
+  - If `state.phase === 'enemy-turn'`, schedules `enemyAct(state)` via `window.setTimeout`, records `recordDamageReceived`, and re-renders.
+- `getRoomDescription(worldState)`, `getAvailableExits(worldState)`, `getRoomId(worldState)` are small helpers.
+
+**`dispatch(action)` responsibilities (simplified)**
+
+- Combat player actions:
+  - `PLAYER_ATTACK`, `PLAYER_DEFEND`, `PLAYER_POTION`, `PLAYER_ABILITY`, `PLAYER_ITEM`.
+  - Each delegates to `combat.js` and updates `gameStats` (damage dealt / items / abilities / turns).
+- Class selection:
+  - `SELECT_CLASS` validates `CLASS_DEFINITIONS[classId]`, then calls `initialStateWithClass(classId)`.
+  - Initializes `questState`, `visitedRooms`, `gameStats`, and sets `phase: 'exploration'` with appropriate log lines.
+- Exploration & movement:
+  - `EXPLORE`: uses `movePlayer`, `onRoomEnter`, `nextRng`, `startNewEncounter`.
+    - Handles room transitions, minimap (`visitedRooms`), RNG-based encounters, quest hooks, and log lines.
+  - `MOVE`: a more minimal movement action that also integrates minimap + `onRoomEnter` and log trimming.
+- Level-up, victory, and aftermath:
+  - `VIEW_LEVEL_UPS`, `LEVEL_UP_CONTINUE`, `CONTINUE_AFTER_BATTLE`, `CONTINUE_EXPLORING`.
+- Encounters & grinding:
+  - `SEEK_ENCOUNTER` (forced encounter).
+- Dialog system:
+  - `TALK_TO_NPC`, `DIALOG_NEXT`, `DIALOG_CLOSE` using `npc-dialog.js` and `getRoomId`.
+- Inventory & quests:
+  - `VIEW_INVENTORY`, `VIEW_QUESTS`, `CLOSE_QUESTS`, `ACCEPT_QUEST` plus inventory-phase actions via `handleInventoryAction`.
+- Defeat / new / save / load / log:
+  - `TRY_AGAIN`, `NEW`, `LOAD`, `SAVE`, `LOG`, and default no-op fallthrough.
+
+
+## 3. Proposed Helper Extraction
+
+To keep this refactor safe, helpers should be **pure functions** of `(state, action)` that return a **new state**. `dispatch` will become a thin router that:
+
+- Selects the correct helper based on `action.type`.
+- Delegates to the helper.
+- Passes the returned state into `setState` (or, in rare cases, `render` when current code already does that).
+
+### 3.1. Class Selection Helper
+
+**New helper:**
+
+```js
+function initializeNewRunWithClass(prevState, classId) {
+  if (!CLASS_DEFINITIONS[classId]) {
+    return pushLog(prevState, 'Unknown class selected.');
+  }
+
+  let next = initialStateWithClass(classId);
+
+  next = {
+    questState: initQuestState(),
+    ...next,
+    phase: 'exploration',
+    log: [
+      `You have chosen the path of the ${classId[0].toUpperCase() + classId.slice(1)}.`,
+      `${getRoomDescription(next.world)} You may explore in any direction.`,
+    ],
+    visitedRooms: initVisitedRooms(1, 1),
+    gameStats: createGameStats(),
+  };
+
+  return next;
+}
+```
+
+**Dispatch change:**
+
+- Replace the current `SELECT_CLASS` block with:
+
+```js
+if (type === 'SELECT_CLASS') {
+  const next = initializeNewRunWithClass(state, action.classId);
+  // `initializeNewRunWithClass` already returns the full next state.
+  // We preserve the legacy `render` call here to avoid changing semantics.
+  if (next.phase === 'exploration') {
+    state = next;
+    return render(state, dispatch);
+  }
+  return setState(next);
+}
+```
+
+- Behavior must remain identical:
+  - Same log text lines.
+  - Same `questState`, `visitedRooms`, `gameStats` initialization.
+  - Same phase and world position.
+
+### 3.2. Combat Player Action Helpers
+
+**New helpers:**
+
+```js
+function handlePlayerAttack(state) { /* wraps current PLAYER_ATTACK logic */ }
+function handlePlayerDefend(state) { /* wraps playerDefend(state) → setState */ }
+function handlePlayerPotion(state) { /* wraps PLAYER_POTION + gameStats */ }
+function handlePlayerAbility(state, abilityId) { /* wraps PLAYER_ABILITY + stats */ }
+function handlePlayerItem(state, itemId) { /* wraps PLAYER_ITEM + stats */ }
+```
+
+Each helper will:
+
+- Take the **current** `state` (and any needed params like `abilityId`, `itemId`).
+- Call into `combat.js` as it does today.
+- Compute HP deltas for damage dealt when needed.
+- Apply `recordDamageDealt`, `recordItemUsed`, `recordAbilityUsed`, `recordTurnPlayed` exactly as now.
+- Return the **next state** object with an updated `gameStats` field.
+
+**Dispatch change:**
+
+- Replace bodies of `PLAYER_ATTACK`, `PLAYER_DEFEND`, `PLAYER_POTION`, `PLAYER_ABILITY`, `PLAYER_ITEM` with:
+
+```js
+if (type === 'PLAYER_ATTACK') {
+  return setState(handlePlayerAttack(state));
+}
+// etc.
+```
+
+This keeps side effects centralized inside the helpers and makes combat wiring easier to test in isolation if we add dedicated unit tests later.
+
+### 3.3. Exploration / Movement Helpers
+
+`EXPLORE` and `MOVE` share:
+
+- Phase guards (`state.phase === 'exploration'`).
+- `movePlayer` integration and `world` updates.
+- Minimap updates via `markRoomVisited`.
+- Quest integration via `onRoomEnter` and room ID mapping.
+- Logging movement and exits.
+
+However, they differ in **UI semantics** and RNG/encounter behavior. To avoid subtle behavior drift, we keep them separate but extract shared primitives.
+
+**New primitives:**
+
+```js
+function getRoomIdFromWorld(worldState) {
+  if (!worldState || worldState.roomRow == null || worldState.roomCol == null) return null;
+  return ROOM_ID_MAP[worldState.roomRow]?.[worldState.roomCol] ?? null;
+}
+
+function applyRoomEnterEffects(state, worldState) {
+  let next = { ...state, world: worldState };
+
+  // Minimap visited-rooms tracking
+  if (worldState && typeof worldState.roomRow === 'number' && typeof worldState.roomCol === 'number') {
+    next = {
+      ...next,
+      visitedRooms: markRoomVisited(
+        next.visitedRooms || [],
+        worldState.roomRow,
+        worldState.roomCol
+      ),
+    };
+  }
+
+  // Quest integration
+  const roomId = getRoomIdFromWorld(worldState);
+  if (roomId && next.questState) {
+    const questResult = onRoomEnter(next.questState, roomId);
+    next = { ...next, questState: questResult.questState };
+  }
+
+  return next;
+}
+```
+
+These helpers will **not** change messages or RNG behavior. They only consolidate the mapping logic and shared state updates.
+
+**EXPLORE-specific helper:**
+
+```js
+function handleExploreAction(state, direction) {
+  // Essentially wraps current EXPLORE block, but calls `applyRoomEnterEffects`.
+}
+```
+
+**MOVE-specific helper:**
+
+```js
+function handleMoveAction(state, direction) {
+  // Wraps current MOVE block, but uses `getRoomIdFromWorld` + `applyRoomEnterEffects`.
+}
+```
+
+`tests/move-dispatch-test.mjs` and `tests/exploration-loop-test.mjs` act as the behavioral spec and must stay green.
+
+### 3.4. Quest & Dialog Helpers (Optional / Later)
+
+If the initial refactor is smooth and well-covered, we can **optionally** extract helpers later for:
+
+- Quest actions:
+  - `handleViewQuests(state)`, `handleCloseQuests(state)`, `handleAcceptQuest(state, questId)`.
+- Dialog actions:
+  - `handleTalkToNPC(state, npcId)`, `handleDialogNext(state)`, `handleDialogClose(state)`.
+
+These will be done in a **follow-up PR**, not the initial refactor, to keep PRs small and safe.
+
+
+## 4. Enemy Turn & `gameStats` Invariants
+
+`setState` handles enemy turns by scheduling an `enemyAct` callback and computing damage received. Any refactor **must not** change these invariants:
+
+- `enemyAct` is only called when `state.phase === 'enemy-turn'`.
+- Damage received is computed once per enemy action as:
+
+```js
+const hpBefore = state.player?.hp ?? 0;
+state = enemyAct(state);
+const dmgReceived = Math.max(0, hpBefore - (state.player?.hp ?? hpBefore));
+```
+
+- When `dmgReceived > 0`, `gameStats` is updated via:
+
+```js
+state = {
+  ...state,
+  gameStats: recordDamageReceived(state.gameStats ?? createGameStats(), dmgReceived),
+};
+```
+
+- `tests/game-stats-wiring-test.mjs` and any additional targeted tests we add for damage-received must remain green.
+
+
+## 5. Stepwise Refactor Plan & Validation
+
+To keep risk low, the refactor will proceed in **small, test-driven steps**, each gated by syntax and test runs:
+
+### Step 0 – Baseline
+
+- Ensure local branch is up to date with `origin/main`.
+- Run:
+  - `node --check src/main.js`
+  - `npm run test:all:quiet`
+
+### Step 1 – Add `initializeNewRunWithClass`
+
+- Add helper near the top of `main.js` (after constants and simple helpers).
+- Replace the `SELECT_CLASS` block to call this helper.
+- Keep using the existing `state = ...; return render(state, dispatch);` pattern to avoid changing behavior.
+- Run syntax + full tests.
+
+### Step 2 – Extract Combat Helpers
+
+- Add `handlePlayerAttack`, `handlePlayerDefend`, `handlePlayerPotion`, `handlePlayerAbility`, `handlePlayerItem`.
+- Replace the corresponding dispatch cases to call these helpers and then `setState`.
+- Run:
+  - `node --check src/main.js`
+  - Targeted tests: `test:combat`, `test:combat-actions`, `test:combat-abilities`, `test:game-stats-wiring`.
+  - Then `npm run test:all:quiet`.
+
+### Step 3 – Shared Room/Quest/Minimap Helpers
+
+- Add `getRoomIdFromWorld` and `applyRoomEnterEffects`.
+- Update `EXPLORE` and `MOVE` to use these helpers **without** changing log text or RNG/encounter thresholds.
+- Ensure:
+  - `tests/move-dispatch-test.mjs`
+  - `tests/exploration-loop-test.mjs`
+  - `tests/minimap-test.mjs`
+  - `tests/quest-log-ui-test.mjs`
+  all pass.
+
+### Step 4 – Optional Cleanups (If Time)
+
+- Remove duplicated inline `ROOM_ID_MAP` constants inside `EXPLORE` and `MOVE` in favor of the top-level one plus `getRoomIdFromWorld`.
+- Lightly reorder helper definitions for readability (e.g., keep helper definitions above `dispatch`).
+
+### Step 5 – Final Policy Checks & PR
+
+- Confirm no banned phrases appear in `src/main.js` by running the existing policy/enforcement tests.
+- Confirm no `eval`, `new Function`, `atob`, or similar constructs were added.
+- Confirm no `package-lock.json` changes.
+- Prepare a PR (e.g., `feature/main-dispatch-cleanup-gpt51`) with a description that emphasizes:
+  - Behavior-preserving refactor.
+  - No integration with `startNewGame()`.
+  - Tests and policy checks all green.
+
+
+## 6. Future Work (Beyond This PR)
+
+Separate, future-safe improvements that build on this refactor:
+
+- Add a dedicated `stats` phase and UI (e.g., `VIEW_STATS` / `CLOSE_STATS`) that uses `getStatsSummary(state.gameStats)`.
+  - NOTE: Claude Opus 4.5 is already working on `stats-display-ui` and wiring a stats phase; any changes in this file must coordinate with that work.
+- Consider a higher-level controller abstraction that can support both `main.js` (single hero) and `game-integration.js` (party-based) behind a compatible interface—but only after a design doc and discussion.
+

--- a/src/data/npcs.js
+++ b/src/data/npcs.js
@@ -3,7 +3,7 @@
  * Part of Story/Dialog Module
  */
 
-const NPCS = {
+export const NPCS = {
   // Quest Givers
   village_elder: {
     id: 'village_elder',
@@ -358,7 +358,7 @@ const NPCS = {
 };
 
 // NPC type definitions for reference
-const NPC_TYPES = {
+export const NPC_TYPES = {
   QUEST_GIVER: 'Gives and tracks quests',
   MERCHANT: 'Buys and sells items',
   TRAINER: 'Teaches skills for gold',

--- a/src/data/quests.js
+++ b/src/data/quests.js
@@ -3,7 +3,7 @@
  * Part of Story/Dialog Module
  */
 
-const QUESTS = {
+export const QUESTS = {
   // Main Quest Line
   main_quest_1: {
     id: 'main_quest_1',

--- a/tests/forbidden-motifs-test.mjs
+++ b/tests/forbidden-motifs-test.mjs
@@ -1,0 +1,103 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+const ROOT_FILES = ['index.html', 'styles.css'];
+const SRC_DIR = 'src';
+
+// Motifs that are banned in production code/assets.
+// We deliberately treat these as whole words to avoid false positives
+// such as "Eastern" matching "easter".
+const BANNED_WORDS = [
+  'egg',
+  'easter',
+  'yolk',
+  'omelet',
+  'omelette',
+  'bunny',
+  'rabbit',
+  'chick',
+  'basket',
+];
+
+// Phrases to ban as simple case-insensitive substrings.
+const BANNED_PHRASES = [
+  'holiday hunt',
+];
+
+function escapeForRegex(word) {
+  return word.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+const WORD_REGEXES = BANNED_WORDS.map((word) => ({
+  word,
+  regex: new RegExp(`\\b${escapeForRegex(word)}\\b`, 'i'),
+}));
+
+function readFileIfExists(filePath) {
+  if (!fs.existsSync(filePath)) return null;
+  return fs.readFileSync(filePath, 'utf8');
+}
+
+function getJsFiles(rootDir) {
+  const results = [];
+  const entries = fs.readdirSync(rootDir, { withFileTypes: true });
+  for (const entry of entries) {
+    const fullPath = path.join(rootDir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...getJsFiles(fullPath));
+    } else if (entry.isFile() && entry.name.endsWith('.js')) {
+      results.push(fullPath);
+    }
+  }
+  return results;
+}
+
+function scanText(text, logicalName) {
+  if (!text) return;
+
+  for (const { word, regex } of WORD_REGEXES) {
+    if (regex.test(text)) {
+      throw new Error(
+        `${logicalName}: forbidden motif word detected: ${JSON.stringify(word)}`,
+      );
+    }
+  }
+
+  const lower = text.toLowerCase();
+  for (const phrase of BANNED_PHRASES) {
+    if (lower.includes(phrase.toLowerCase())) {
+      throw new Error(
+        `${logicalName}: forbidden motif phrase detected: ${JSON.stringify(phrase)}`,
+      );
+    }
+  }
+}
+
+// Scan top-level HTML/CSS if present.
+for (const file of ROOT_FILES) {
+  const text = readFileIfExists(file);
+  if (text != null) {
+    scanText(text, file);
+  }
+}
+
+// Scan all JS under src/.
+const jsFiles = getJsFiles(SRC_DIR);
+let filesScanned = 0;
+
+for (const filePath of jsFiles) {
+  const text = fs.readFileSync(filePath, 'utf8');
+  scanText(text, filePath);
+  filesScanned += 1;
+}
+
+console.log(
+  `[forbidden-motifs-test] Scanned ${filesScanned} JS files under ${SRC_DIR} plus root assets`,
+);
+console.log('[forbidden-motifs-test] OK');

--- a/tests/npc-data-integrity-test.mjs
+++ b/tests/npc-data-integrity-test.mjs
@@ -1,0 +1,157 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { createRequire } from 'node:module';
+
+import { EXPLORATION_QUESTS } from '../src/data/exploration-quests.js';
+
+const require = createRequire(import.meta.url);
+const { QUESTS } = require('../src/data/quests.js');
+const { NPCS, NPC_TYPES } = require('../src/data/npcs.js');
+
+const NPC_TYPE_KEYS = Object.keys(NPC_TYPES);
+
+function isNonEmptyString(value) {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+describe('NPCS data integrity', () => {
+  it('has NPCs with consistent basic fields', () => {
+    const npcKeys = Object.keys(NPCS);
+    assert.ok(npcKeys.length > 0, 'NPCS should contain at least one NPC');
+
+    for (const key of npcKeys) {
+      const npc = NPCS[key];
+      assert.ok(npc, `NPC ${key} is defined`);
+      assert.strictEqual(npc.id, key, `NPC id should match key for ${key}`);
+      assert.ok(isNonEmptyString(npc.name), `NPC ${key} must have a name`);
+      assert.ok(isNonEmptyString(npc.type), `NPC ${key} must have a type`);
+      assert.ok(
+        NPC_TYPE_KEYS.includes(npc.type),
+        `NPC ${key} type ${npc.type} must be one of ${NPC_TYPE_KEYS.join(', ')}`
+      );
+
+      if (npc.location !== undefined) {
+        assert.ok(isNonEmptyString(npc.location), `NPC ${key} location, when present, must be a non-empty string`);
+      }
+
+      if (npc.dialog !== undefined) {
+        assert.ok(isNonEmptyString(npc.dialog), `NPC ${key} dialog, when present, must be a non-empty string`);
+      }
+    }
+  });
+
+  it('has quests on NPCs that reference existing quest definitions', () => {
+    const npcKeys = Object.keys(NPCS);
+
+    for (const key of npcKeys) {
+      const npc = NPCS[key];
+      if (!Array.isArray(npc.quests)) continue;
+
+      for (const questId of npc.quests) {
+        assert.ok(
+          typeof questId === 'string' && (questId in QUESTS || questId in EXPLORATION_QUESTS),
+          `NPC ${key} quest reference ${questId} must exist in QUESTS or EXPLORATION_QUESTS`
+        );
+      }
+    }
+  });
+
+  it('has personality traits in the [0, 1] range when present', () => {
+    for (const [key, npc] of Object.entries(NPCS)) {
+      if (!npc.personality) continue;
+      for (const [trait, value] of Object.entries(npc.personality)) {
+        assert.ok(
+          typeof value === 'number' && value >= 0 && value <= 1,
+          `NPC ${key} personality trait ${trait} must be between 0 and 1`
+        );
+      }
+    }
+  });
+
+  it('has well-formed shop inventories for merchant NPCs', () => {
+    for (const [key, npc] of Object.entries(NPCS)) {
+      if (npc.type !== 'MERCHANT' || !npc.shopInventory) continue;
+
+      assert.ok(
+        typeof npc.shopInventory === 'object' && !Array.isArray(npc.shopInventory),
+        `NPC ${key} shopInventory must be an object`
+      );
+
+      for (const [category, items] of Object.entries(npc.shopInventory)) {
+        assert.ok(isNonEmptyString(category), `NPC ${key} shop category name must be non-empty string`);
+        assert.ok(Array.isArray(items), `NPC ${key} shop category ${category} must be an array`);
+        for (const itemId of items) {
+          assert.ok(isNonEmptyString(itemId), `NPC ${key} shop item id in category ${category} must be non-empty string`);
+        }
+      }
+
+      if (npc.buyMultiplier !== undefined) {
+        assert.ok(
+          typeof npc.buyMultiplier === 'number' && npc.buyMultiplier > 0,
+          `NPC ${key} buyMultiplier must be a positive number when present`
+        );
+      }
+
+      if (npc.sellMultiplier !== undefined) {
+        assert.ok(
+          typeof npc.sellMultiplier === 'number' && npc.sellMultiplier > 0,
+          `NPC ${key} sellMultiplier must be a positive number when present`
+        );
+      }
+    }
+  });
+
+  it('has companions with basic stats and skills when applicable', () => {
+    for (const [key, npc] of Object.entries(NPCS)) {
+      if (npc.type !== 'COMPANION') continue;
+
+      assert.ok(npc.stats && typeof npc.stats === 'object', `Companion NPC ${key} must have stats object`);
+      assert.ok(Array.isArray(npc.skills), `Companion NPC ${key} must have skills array`);
+      assert.ok(npc.skills.length > 0, `Companion NPC ${key} must have at least one skill`);
+
+      const requiredStatKeys = ['level', 'hp', 'mp', 'attack', 'defense', 'speed'];
+      for (const statKey of requiredStatKeys) {
+        const value = npc.stats[statKey];
+        assert.ok(
+          typeof value === 'number' && Number.isFinite(value),
+          `Companion NPC ${key} stats.${statKey} must be a finite number`
+        );
+      }
+    }
+  });
+
+  it('has basic structure for boss NPCs when present', () => {
+    for (const [key, npc] of Object.entries(NPCS)) {
+      if (npc.type !== 'BOSS') continue;
+
+      assert.ok(npc.stats && typeof npc.stats === 'object', `Boss NPC ${key} must have stats object`);
+      assert.ok(
+        typeof npc.isBoss === 'boolean' || npc.isBoss === undefined,
+        `Boss NPC ${key} isBoss flag, when present, must be boolean`
+      );
+
+      if (npc.drops) {
+        const { guaranteed, random } = npc.drops;
+        if (guaranteed !== undefined) {
+          assert.ok(Array.isArray(guaranteed), `Boss NPC ${key} guaranteed drops must be an array when present`);
+          for (const itemId of guaranteed) {
+            assert.ok(isNonEmptyString(itemId), `Boss NPC ${key} guaranteed drop id must be non-empty string`);
+          }
+        }
+        if (random !== undefined) {
+          assert.ok(Array.isArray(random), `Boss NPC ${key} random drops must be an array when present`);
+          for (const drop of random) {
+            assert.ok(drop && typeof drop === 'object', `Boss NPC ${key} random drop entry must be an object`);
+            assert.ok(isNonEmptyString(drop.item), `Boss NPC ${key} random drop item id must be non-empty string`);
+            if (drop.chance !== undefined) {
+              assert.ok(
+                typeof drop.chance === 'number' && drop.chance >= 0 && drop.chance <= 1,
+                `Boss NPC ${key} random drop chance must be between 0 and 1`
+              );
+            }
+          }
+        }
+      }
+    }
+  });
+});

--- a/tests/quest-data-integrity-test.mjs
+++ b/tests/quest-data-integrity-test.mjs
@@ -1,0 +1,210 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { createRequire } from 'node:module';
+
+import { EXPLORATION_QUESTS } from '../src/data/exploration-quests.js';
+
+const require = createRequire(import.meta.url);
+const { QUESTS } = require('../src/data/quests.js');
+const { NPCS } = require('../src/data/npcs.js');
+
+const QUEST_TYPES = ['MAIN', 'SIDE', 'DAILY', 'ACHIEVEMENT'];
+const OBJECTIVE_TYPES = ['TALK', 'KILL', 'COLLECT', 'DELIVER', 'EXPLORE', 'ESCORT', 'INTERACT', 'CUSTOM'];
+
+function isNonEmptyString(value) {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+describe('QUESTS data integrity', () => {
+  it('has quests with well-formed structure', () => {
+    const questIds = Object.keys(QUESTS);
+    assert.ok(questIds.length > 0, 'QUESTS should contain quests');
+
+    for (const questId of questIds) {
+      const quest = QUESTS[questId];
+      assert.ok(quest, `Quest ${questId} is defined`);
+      assert.strictEqual(quest.id, questId, `Quest id should match key for ${questId}`);
+      assert.ok(isNonEmptyString(quest.name), `Quest ${questId} must have a name`);
+      assert.ok(isNonEmptyString(quest.description), `Quest ${questId} must have a description`);
+      assert.ok(QUEST_TYPES.includes(quest.type), `Quest ${questId} has valid type`);
+      assert.ok(Number.isInteger(quest.level) && quest.level >= 1, `Quest ${questId} has valid level`);
+      assert.ok(Array.isArray(quest.stages) && quest.stages.length > 0, `Quest ${questId} must have at least one stage`);
+      assert.ok(Array.isArray(quest.prerequisites), `Quest ${questId} prerequisites must be an array`);
+
+      // prerequisites reference existing quests within QUESTS
+      for (const prereq of quest.prerequisites) {
+        assert.ok(
+          typeof prereq === 'string' && prereq in QUESTS,
+          `Quest ${questId} prerequisite ${prereq} must reference another quest in QUESTS`
+        );
+      }
+
+      // validate stages
+      const stageIds = new Set();
+      for (const stage of quest.stages) {
+        assert.ok(isNonEmptyString(stage.id), `Quest ${questId} stage must have id`);
+        assert.ok(!stageIds.has(stage.id), `Quest ${questId} stage id ${stage.id} must be unique`);
+        stageIds.add(stage.id);
+        assert.ok(isNonEmptyString(stage.name), `Quest ${questId} stage ${stage.id} must have name`);
+        assert.ok(isNonEmptyString(stage.description), `Quest ${questId} stage ${stage.id} must have description`);
+        assert.ok(
+          Array.isArray(stage.objectives) && stage.objectives.length > 0,
+          `Quest ${questId} stage ${stage.id} must have objectives`
+        );
+
+        for (const objective of stage.objectives) {
+          assert.ok(isNonEmptyString(objective.id), `Objective in quest ${questId}/${stage.id} must have id`);
+          assert.ok(
+            OBJECTIVE_TYPES.includes(objective.type),
+            `Objective ${objective.id} in quest ${questId}/${stage.id} has valid type`
+          );
+          assert.ok(
+            isNonEmptyString(objective.description),
+            `Objective ${objective.id} in quest ${questId}/${stage.id} must have description`
+          );
+          if (objective.required !== undefined) {
+            assert.ok(
+              typeof objective.required === 'boolean',
+              `Objective ${objective.id} in quest ${questId}/${stage.id} required flag must be boolean`
+            );
+          }
+
+          switch (objective.type) {
+            case 'TALK':
+              assert.ok(
+                isNonEmptyString(objective.npcId),
+                `TALK objective ${objective.id} in quest ${questId}/${stage.id} must specify npcId`
+              );
+              assert.ok(
+                NPCS[objective.npcId],
+                `TALK objective ${objective.id} in quest ${questId}/${stage.id} references existing NPC ${objective.npcId}`
+              );
+              break;
+            case 'KILL':
+              assert.ok(
+                isNonEmptyString(objective.enemyType),
+                `KILL objective ${objective.id} in quest ${questId}/${stage.id} must specify enemyType`
+              );
+              assert.ok(
+                Number.isInteger(objective.count) && objective.count > 0,
+                `KILL objective ${objective.id} in quest ${questId}/${stage.id} must have positive count`
+              );
+              break;
+            case 'COLLECT':
+              assert.ok(
+                isNonEmptyString(objective.itemId),
+                `COLLECT objective ${objective.id} in quest ${questId}/${stage.id} must specify itemId`
+              );
+              assert.ok(
+                Number.isInteger(objective.count) && objective.count > 0,
+                `COLLECT objective ${objective.id} in quest ${questId}/${stage.id} must have positive count`
+              );
+              break;
+            case 'DELIVER':
+              assert.ok(
+                isNonEmptyString(objective.npcId),
+                `DELIVER objective ${objective.id} in quest ${questId}/${stage.id} must specify npcId`
+              );
+              assert.ok(
+                NPCS[objective.npcId],
+                `DELIVER objective ${objective.id} in quest ${questId}/${stage.id} references existing NPC ${objective.npcId}`
+              );
+              if (objective.itemIds !== undefined) {
+                assert.ok(
+                  Array.isArray(objective.itemIds) && objective.itemIds.every(isNonEmptyString),
+                  `DELIVER objective ${objective.id} in quest ${questId}/${stage.id} itemIds must be array of strings`
+                );
+              }
+              break;
+            case 'EXPLORE':
+              assert.ok(
+                isNonEmptyString(objective.locationId),
+                `EXPLORE objective ${objective.id} in quest ${questId}/${stage.id} must specify locationId`
+              );
+              break;
+            case 'ESCORT':
+              assert.ok(
+                isNonEmptyString(objective.npcId),
+                `ESCORT objective ${objective.id} in quest ${questId}/${stage.id} must specify npcId`
+              );
+              assert.ok(
+                NPCS[objective.npcId],
+                `ESCORT objective ${objective.id} in quest ${questId}/${stage.id} references existing NPC ${objective.npcId}`
+              );
+              assert.ok(
+                isNonEmptyString(objective.destinationId),
+                `ESCORT objective ${objective.id} in quest ${questId}/${stage.id} must specify destinationId`
+              );
+              break;
+            case 'INTERACT':
+              assert.ok(
+                isNonEmptyString(objective.interactId),
+                `INTERACT objective ${objective.id} in quest ${questId}/${stage.id} must specify interactId`
+              );
+              break;
+            case 'CUSTOM':
+              // no additional structural guarantees yet
+              break;
+            default:
+              // Should be unreachable due to OBJECTIVE_TYPES guard
+              throw new Error(`Unhandled objective type ${objective.type}`);
+          }
+        }
+      }
+
+      // validate nextStage references within quest
+      const validStageIds = new Set(stageIds);
+      for (const stage of quest.stages) {
+        if (stage.nextStage != null) {
+          assert.ok(
+            typeof stage.nextStage === 'string' && validStageIds.has(stage.nextStage),
+            `Quest ${questId} stage ${stage.id} nextStage must reference another stage id or be null`
+          );
+        }
+      }
+
+      // validate rewards structure
+      const rewards = quest.rewards || {};
+      if (rewards.gold !== undefined) {
+        assert.ok(
+          Number.isInteger(rewards.gold) && rewards.gold >= 0,
+          `Quest ${questId} rewards.gold must be non-negative integer`
+        );
+      }
+      if (rewards.experience !== undefined) {
+        assert.ok(
+          Number.isInteger(rewards.experience) && rewards.experience >= 0,
+          `Quest ${questId} rewards.experience must be non-negative integer`
+        );
+      }
+      if (rewards.items !== undefined) {
+        assert.ok(Array.isArray(rewards.items), `Quest ${questId} rewards.items must be array when present`);
+        for (const rewardItem of rewards.items) {
+          assert.ok(isNonEmptyString(rewardItem), `Quest ${questId} reward item id must be non-empty string`);
+        }
+      }
+    }
+  });
+});
+
+describe('EXPLORATION_QUESTS metadata', () => {
+  it('uses valid quest types and prerequisite references', () => {
+    const explorationIds = Object.keys(EXPLORATION_QUESTS);
+    assert.ok(explorationIds.length > 0, 'EXPLORATION_QUESTS should contain quests');
+
+    for (const questId of explorationIds) {
+      const quest = EXPLORATION_QUESTS[questId];
+      assert.ok(quest, `Exploration quest ${questId} is defined`);
+      assert.strictEqual(quest.id, questId, `Exploration quest id should match key for ${questId}`);
+      assert.ok(QUEST_TYPES.includes(quest.type), `Exploration quest ${questId} has valid type`);
+      assert.ok(Array.isArray(quest.prerequisites), `Exploration quest ${questId} prerequisites must be array`);
+
+      for (const prereq of quest.prerequisites) {
+        assert.ok(
+          typeof prereq === 'string' && (prereq in EXPLORATION_QUESTS || prereq in QUESTS),
+          `Exploration quest ${questId} prerequisite ${prereq} must reference another quest`
+        );
+      }
+    }
+  });
+});

--- a/tests/whitespace-guard-test.mjs
+++ b/tests/whitespace-guard-test.mjs
@@ -1,0 +1,86 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function getJsFiles(rootDir) {
+  const results = [];
+  const entries = fs.readdirSync(rootDir, { withFileTypes: true });
+  for (const entry of entries) {
+    const fullPath = path.join(rootDir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...getJsFiles(fullPath));
+    } else if (entry.isFile() && entry.name.endsWith('.js')) {
+      results.push(fullPath);
+    }
+  }
+  return results;
+}
+
+function getMaxLeadingSpaces(text) {
+  let max = 0;
+  for (const line of text.split('\n')) {
+    let i = 0;
+    while (i < line.length && line[i] === ' ') i += 1;
+    if (i > max) max = i;
+  }
+  return max;
+}
+
+const SRC_DIR = path.join('src');
+const jsFiles = getJsFiles(SRC_DIR);
+
+// Tokens associated with obfuscation or covert channels that should
+// never appear in production source files. This complements the
+// repo's explicit ban on eval / Function / atob / btoa, etc.
+const BANNED_TOKENS = [
+  'eval(',
+  'new Function',
+  'Function(',
+  'Function (',
+  'atob(',
+  'btoa(',
+  'unescape(',
+];
+
+let filesChecked = 0;
+
+for (const filePath of jsFiles) {
+  const buf = fs.readFileSync(filePath);
+  const text = buf.toString('utf8');
+
+  const totalBytes = buf.length || 1;
+  let spaceCount = 0;
+  for (const byte of buf) {
+    if (byte === 0x20) spaceCount += 1;
+  }
+  const spaceRatio = spaceCount / totalBytes;
+  const maxLeadingSpaces = getMaxLeadingSpaces(text);
+
+  // Thresholds intentionally generous but sufficient to catch
+  // pathological padding or whitespace-based steganography.
+  assert(
+    spaceRatio < 0.6,
+    `${filePath}: spaceRatio too high: ${spaceRatio}`,
+  );
+  assert(
+    maxLeadingSpaces <= 80,
+    `${filePath}: maxLeadingSpaces too high: ${maxLeadingSpaces}`,
+  );
+
+  for (const token of BANNED_TOKENS) {
+    assert(
+      !text.includes(token),
+      `${filePath}: disallowed token detected: ${JSON.stringify(token)}`,
+    );
+  }
+
+  filesChecked += 1;
+}
+
+console.log(`[whitespace-guard-test] Checked ${filesChecked} JS files under src/`);
+console.log('[whitespace-guard-test] OK');


### PR DESCRIPTION
Adds integrity tests for QUESTS/NPCS data modules plus repo-wide content/whitespace guards, keeping runtime behavior unchanged.

**Key changes**
- New tests:
  - \: validates QUESTS structure, objective types/links, rewards, and EXPLORATION_QUESTS metadata.
  - \: validates NPCS/NPC_TYPES structure, quest references, merchant inventories, companions, and boss drops.
  - \: scans all src/**/*.js for extreme whitespace patterns and banned obfuscation tokens (eval/new Function/atob/btoa/unescape).
  - \: enforces the no-egg/holiday motif policy across index.html, styles.css, and src/**/*.js.
- Data modules:
  - Convert src/data/quests.js and src/data/npcs.js to dual ESM + CommonJS exports (export const + guarded module.exports) so both import styles continue to work under Node 20.
- Docs:
  - \: design-only plan for a future, behavior-preserving main.js dispatch refactor; no runtime changes in this PR.

**Status**
- npm run test:all:quiet passes on this branch, including all new tests.
- No package-lock.json changes.