### PR TITLE
fix: remove escaped backticks in render.js template literals

### DIFF
--- a/src/render.js
+++ b/src/render.js
@@ -817,11 +817,11 @@ export function render(state, dispatch) {
 
     hud.innerHTML = shopHtml;
 
-    actions.innerHTML = \`
+    actions.innerHTML = `
       <div class="buttons">
         <button id="btnCloseShop">Leave Shop</button>
       </div>
-    \`;
+    `;
 
     attachShopHandlers(hud, dispatch);
     document.getElementById('btnCloseShop').onclick = () => dispatch({ type: 'CLOSE_SHOP' });
@@ -829,7 +829,7 @@ export function render(state, dispatch) {
     log.innerHTML = state.log
       .slice()
       .reverse()
-      .map((line) => \`<div class="logLine">\${esc(line)}</div>\`)
+      .map((line) => `<div class="logLine">${esc(line)}</div>`)
       .join('');
     return;
   }


### PR DESCRIPTION
## Summary
Fixes broken JavaScript syntax in `src/render.js` caused by escaped backticks introduced during the Boss Battle System merge (PR #99).

## Changes
- Removed escaped backticks (`\\``) and replaced with proper template literal backticks on 3 lines:
  - Line 820: shop actions innerHTML template
  - Line 824: closing template literal
  - Line 832: log line map template

## Testing
- `node --check src/render.js` passes ✅
- `npm test` passes ✅
- `npm run test:all` passes (53/53) ✅

Note: GPT-5.2 announced a PR #100 to fix this same issue but the PR never materialized (returns 404). This fix addresses the same problem.