### PR TITLE
feat: Talent Handler Integration with Level-Up Skill Points

### DIFF
--- a/src/handlers/ui-handler.js
+++ b/src/handlers/ui-handler.js
@@ -10,6 +10,7 @@ import { advanceDialog } from '../npc-dialog.js';
 import { loadSettings, updateSetting, resetSettings, saveSettings } from '../settings.js';
 import { createShopState, buyItem, sellItem } from '../shop.js';
 import { createCraftingState, craftItem } from '../crafting.js';
+import { createTalentState, allocateTalent, deallocateTalent, resetAllTalents } from '../talents.js';
 
 function getRoomDescription(worldState) {
   const room = getCurrentRoom(worldState);
@@ -280,6 +281,45 @@ export function handleUIAction(state, action) {
       ...state,
       craftingUI: { ...state.craftingUI, message: result.message },
     };
+  }
+
+  // Talents
+  if (type === 'VIEW_TALENTS') {
+    if (state.phase === 'class-select') return null;
+    if (!state.talentState) {
+      state = { ...state, talentState: createTalentState() };
+    }
+    return { ...state, phase: 'talents', previousPhase: state.phase };
+  }
+
+  if (type === 'ALLOCATE_TALENT') {
+    if (state.phase !== 'talents' || !action.talentId || !state.talentState) return null;
+    const result = allocateTalent(state.talentState, action.talentId);
+    if (result.success) {
+      return pushLog({ ...state, talentState: result.newState }, 'Allocated talent point.');
+    }
+    return pushLog(state, result.error || 'Unable to allocate talent.');
+  }
+
+  if (type === 'DEALLOCATE_TALENT') {
+    if (state.phase !== 'talents' || !action.talentId || !state.talentState) return null;
+    const result = deallocateTalent(state.talentState, action.talentId);
+    if (result.success) {
+      return pushLog({ ...state, talentState: result.newState }, 'Deallocated talent point.');
+    }
+    return pushLog(state, result.error || 'Unable to deallocate talent.');
+  }
+
+  if (type === 'RESET_TALENTS') {
+    if (state.phase !== 'talents' || !state.talentState) return null;
+    const talentState = resetAllTalents(state.talentState);
+    return pushLog({ ...state, talentState }, 'All talents have been reset.');
+  }
+
+  if (type === 'CLOSE_TALENTS') {
+    if (state.phase !== 'talents') return null;
+    const returnPhase = state.previousPhase || 'exploration';
+    return { ...state, phase: returnPhase };
   }
 
   return null;

--- a/src/state-transitions.js
+++ b/src/state-transitions.js
@@ -2,6 +2,9 @@ import { calcLevel } from './characters/stats.js';
 import { checkLevelUps } from './level-up.js';
 import { createBattleSummary } from './battle-summary.js';
 import { pushLog } from './state.js';
+import { addSkillPoints, createTalentState } from './talents.js';
+
+const SKILL_POINTS_PER_LEVEL = 1;
 
 /**
  * Handles automatic state updates based on phase transitions.
@@ -28,6 +31,10 @@ export function handleStateTransitions(prevState, nextState) {
         if (levelUps.length > 0) {
           // Update player level and stats to match post-level-up
           const lu = levelUps[0];
+          const levelsGained = lu.newLevel - oldLevel;
+          const pointsToAdd = levelsGained * SKILL_POINTS_PER_LEVEL;
+          const currentTalentState = next.talentState || createTalentState();
+          const newTalentState = addSkillPoints(currentTalentState, pointsToAdd);
           next = {
             ...next,
             player: {
@@ -41,9 +48,11 @@ export function handleStateTransitions(prevState, nextState) {
               def: lu.newStats.def,
               spd: lu.newStats.spd,
             },
+            talentState: newTalentState,
             pendingLevelUps: levelUps,
           };
           next = pushLog(next, `${player.name} reached level ${lu.newLevel}!`);
+          next = pushLog(next, `Gained ${pointsToAdd} skill point(s)!`);
         }
       }
     }

--- a/tests/talent-handler-integration-test.mjs
+++ b/tests/talent-handler-integration-test.mjs
@@ -1,0 +1,353 @@
+/**
+ * Talent Handler Integration Tests
+ * Tests for VIEW_TALENTS, ALLOCATE_TALENT, DEALLOCATE_TALENT, RESET_TALENTS, CLOSE_TALENTS handlers
+ * and level-up skill point granting integration
+ */
+
+import { describe, it, beforeEach } from 'node:test';
+import assert from 'node:assert';
+import { handleUIAction } from '../src/handlers/ui-handler.js';
+import { handleStateTransitions } from '../src/state-transitions.js';
+import { createTalentState, addSkillPoints, allocateTalent } from '../src/talents.js';
+
+// Helper to create a base game state
+function createBaseState(overrides = {}) {
+  return {
+    phase: 'exploration',
+    player: {
+      name: 'Hero',
+      classId: 'warrior',
+      level: 1,
+      xp: 0,
+      hp: 100,
+      maxHp: 100,
+      mp: 50,
+      maxMp: 50,
+      atk: 15,
+      def: 10,
+      spd: 12,
+      stats: { maxHp: 100, maxMp: 50, atk: 15, def: 10, spd: 12 },
+      gold: 100,
+      inventory: []
+    },
+    log: [],
+    ...overrides
+  };
+}
+
+describe('Talent Handler Integration', () => {
+  describe('VIEW_TALENTS handler', () => {
+    it('should open talents screen from exploration', () => {
+      const state = createBaseState();
+      const result = handleUIAction(state, { type: 'VIEW_TALENTS' });
+      
+      assert.ok(result, 'Should return a new state');
+      assert.strictEqual(result.phase, 'talents');
+      assert.strictEqual(result.previousPhase, 'exploration');
+      assert.ok(result.talentState, 'Should initialize talentState');
+      assert.strictEqual(result.talentState.availablePoints, 0);
+    });
+
+    it('should preserve existing talentState when reopening', () => {
+      const existingTalentState = addSkillPoints(createTalentState(), 5);
+      const state = createBaseState({ talentState: existingTalentState });
+      const result = handleUIAction(state, { type: 'VIEW_TALENTS' });
+      
+      assert.strictEqual(result.talentState.availablePoints, 5);
+    });
+
+    it('should not open talents during class-select', () => {
+      const state = createBaseState({ phase: 'class-select' });
+      const result = handleUIAction(state, { type: 'VIEW_TALENTS' });
+      
+      assert.strictEqual(result, null);
+    });
+  });
+
+  describe('ALLOCATE_TALENT handler', () => {
+    it('should allocate talent when in talents phase with points', () => {
+      let state = createBaseState({ phase: 'talents' });
+      state.talentState = addSkillPoints(createTalentState(), 5);
+      
+      const result = handleUIAction(state, { type: 'ALLOCATE_TALENT', talentId: 'sharpened-blade' });
+      
+      assert.ok(result, 'Should return a new state');
+      assert.strictEqual(result.talentState.availablePoints, 4);
+      assert.strictEqual(result.talentState.allocatedTalents['sharpened-blade'], 1);
+      assert.ok(result.log.some(line => line.includes('Allocated')), 'Should have allocation log');
+    });
+
+    it('should fail allocation without points', () => {
+      let state = createBaseState({ phase: 'talents' });
+      state.talentState = createTalentState(); // 0 points
+      
+      const result = handleUIAction(state, { type: 'ALLOCATE_TALENT', talentId: 'sharpened-blade' });
+      
+      assert.ok(result, 'Should return a new state');
+      assert.ok(result.log.some(line => line.includes('Unable') || line.includes('points')), 'Should have error log');
+    });
+
+    it('should not allocate when not in talents phase', () => {
+      let state = createBaseState({ phase: 'exploration' });
+      state.talentState = addSkillPoints(createTalentState(), 5);
+      
+      const result = handleUIAction(state, { type: 'ALLOCATE_TALENT', talentId: 'sharpened-blade' });
+      
+      assert.strictEqual(result, null);
+    });
+
+    it('should not allocate without talentId', () => {
+      let state = createBaseState({ phase: 'talents' });
+      state.talentState = addSkillPoints(createTalentState(), 5);
+      
+      const result = handleUIAction(state, { type: 'ALLOCATE_TALENT' });
+      
+      assert.strictEqual(result, null);
+    });
+  });
+
+  describe('DEALLOCATE_TALENT handler', () => {
+    it('should deallocate talent when in talents phase', () => {
+      let state = createBaseState({ phase: 'talents' });
+      state.talentState = addSkillPoints(createTalentState(), 5);
+      // Allocate first
+      const allocResult = allocateTalent(state.talentState, 'sharpened-blade');
+      state.talentState = allocResult.newState;
+      
+      const result = handleUIAction(state, { type: 'DEALLOCATE_TALENT', talentId: 'sharpened-blade' });
+      
+      assert.ok(result, 'Should return a new state');
+      assert.strictEqual(result.talentState.availablePoints, 5);
+      assert.ok(result.log.some(line => line.includes('Deallocated')), 'Should have deallocation log');
+    });
+
+    it('should fail deallocation on unallocated talent', () => {
+      let state = createBaseState({ phase: 'talents' });
+      state.talentState = addSkillPoints(createTalentState(), 5);
+      
+      const result = handleUIAction(state, { type: 'DEALLOCATE_TALENT', talentId: 'sharpened-blade' });
+      
+      assert.ok(result, 'Should return a new state');
+      assert.ok(result.log.some(line => line.includes('Unable') || line.includes('no points allocated')), 'Should have error log');
+    });
+  });
+
+  describe('RESET_TALENTS handler', () => {
+    it('should reset all talents and refund points', () => {
+      let state = createBaseState({ phase: 'talents' });
+      state.talentState = addSkillPoints(createTalentState(), 5);
+      // Allocate some talents
+      let result = allocateTalent(state.talentState, 'sharpened-blade');
+      state.talentState = result.newState;
+      result = allocateTalent(state.talentState, 'sharpened-blade');
+      state.talentState = result.newState;
+      
+      assert.strictEqual(state.talentState.availablePoints, 3);
+      
+      const resetResult = handleUIAction(state, { type: 'RESET_TALENTS' });
+      
+      assert.ok(resetResult, 'Should return a new state');
+      assert.strictEqual(resetResult.talentState.availablePoints, 5);
+      assert.strictEqual(resetResult.talentState.totalPointsSpent, 0);
+      assert.ok(resetResult.log.some(line => line.includes('reset')), 'Should have reset log');
+    });
+
+    it('should not reset when not in talents phase', () => {
+      let state = createBaseState({ phase: 'exploration' });
+      state.talentState = addSkillPoints(createTalentState(), 5);
+      
+      const result = handleUIAction(state, { type: 'RESET_TALENTS' });
+      
+      assert.strictEqual(result, null);
+    });
+  });
+
+  describe('CLOSE_TALENTS handler', () => {
+    it('should return to previous phase', () => {
+      const state = createBaseState({ 
+        phase: 'talents', 
+        previousPhase: 'exploration',
+        talentState: createTalentState()
+      });
+      
+      const result = handleUIAction(state, { type: 'CLOSE_TALENTS' });
+      
+      assert.ok(result, 'Should return a new state');
+      assert.strictEqual(result.phase, 'exploration');
+    });
+
+    it('should default to exploration if no previousPhase', () => {
+      const state = createBaseState({ 
+        phase: 'talents',
+        talentState: createTalentState()
+      });
+      
+      const result = handleUIAction(state, { type: 'CLOSE_TALENTS' });
+      
+      assert.strictEqual(result.phase, 'exploration');
+    });
+
+    it('should not close when not in talents phase', () => {
+      const state = createBaseState({ phase: 'exploration' });
+      
+      const result = handleUIAction(state, { type: 'CLOSE_TALENTS' });
+      
+      assert.strictEqual(result, null);
+    });
+  });
+});
+
+describe('Level-Up Skill Point Integration', () => {
+  it('should grant skill points on level-up', () => {
+    const prevState = createBaseState({
+      phase: 'combat',
+      player: {
+        name: 'Hero',
+        classId: 'warrior',
+        level: 1,
+        xp: 0,
+        hp: 100,
+        maxHp: 100,
+        mp: 50,
+        maxMp: 50,
+        atk: 15,
+        def: 10,
+        spd: 12,
+        int: 8,
+        lck: 5,
+        stats: { maxHp: 100, maxMp: 50, atk: 15, def: 10, spd: 12, int: 8, lck: 5 },
+      },
+      xpGained: 150
+    });
+    
+    const nextState = {
+      ...prevState,
+      phase: 'victory',
+      player: {
+        ...prevState.player,
+        xp: 150 // XP that should trigger level up
+      }
+    };
+    
+    const result = handleStateTransitions(prevState, nextState);
+    
+    assert.ok(result.talentState, 'Should have talentState');
+    assert.ok(result.talentState.availablePoints >= 1, 'Should have at least 1 skill point');
+    assert.ok(result.log.some(line => line.includes('skill point')), 'Should log skill point gain');
+  });
+
+  it('should initialize talentState if not present on level-up', () => {
+    const prevState = createBaseState({
+      phase: 'combat',
+      player: {
+        name: 'Hero',
+        classId: 'warrior',
+        level: 1,
+        xp: 0,
+        hp: 100,
+        maxHp: 100,
+        mp: 50,
+        maxMp: 50,
+        atk: 15,
+        def: 10,
+        spd: 12,
+        int: 8,
+        lck: 5,
+        stats: { maxHp: 100, maxMp: 50, atk: 15, def: 10, spd: 12, int: 8, lck: 5 },
+      },
+      xpGained: 150
+    });
+    // Explicitly no talentState
+    delete prevState.talentState;
+    
+    const nextState = {
+      ...prevState,
+      phase: 'victory',
+      player: {
+        ...prevState.player,
+        xp: 150
+      }
+    };
+    
+    const result = handleStateTransitions(prevState, nextState);
+    
+    // If level up happens, talentState should be created
+    if (result.pendingLevelUps && result.pendingLevelUps.length > 0) {
+      assert.ok(result.talentState, 'Should create talentState on level-up');
+    }
+  });
+
+  it('should add to existing talentState points on level-up', () => {
+    const existingTalentState = addSkillPoints(createTalentState(), 3);
+    
+    const prevState = createBaseState({
+      phase: 'combat',
+      talentState: existingTalentState,
+      player: {
+        name: 'Hero',
+        classId: 'warrior',
+        level: 1,
+        xp: 0,
+        hp: 100,
+        maxHp: 100,
+        mp: 50,
+        maxMp: 50,
+        atk: 15,
+        def: 10,
+        spd: 12,
+        int: 8,
+        lck: 5,
+        stats: { maxHp: 100, maxMp: 50, atk: 15, def: 10, spd: 12, int: 8, lck: 5 },
+      },
+      xpGained: 150
+    });
+    
+    const nextState = {
+      ...prevState,
+      phase: 'victory',
+      player: {
+        ...prevState.player,
+        xp: 150
+      }
+    };
+    
+    const result = handleStateTransitions(prevState, nextState);
+    
+    // If level up happens, should add to existing points
+    if (result.pendingLevelUps && result.pendingLevelUps.length > 0) {
+      assert.ok(result.talentState.availablePoints >= 4, 'Should have existing + new points');
+    }
+  });
+});
+
+describe('Forbidden Content Check', () => {
+  it('should not contain easter egg patterns in handler code', async () => {
+    const fs = await import('fs');
+    const path = await import('path');
+    
+    const handlerPath = path.join(process.cwd(), 'src/handlers/ui-handler.js');
+    const transitionsPath = path.join(process.cwd(), 'src/state-transitions.js');
+    
+    const handlerContent = fs.readFileSync(handlerPath, 'utf-8');
+    const transitionsContent = fs.readFileSync(transitionsPath, 'utf-8');
+    
+    const forbiddenPatterns = [
+      /\begg\b/i,
+      /\beaster\b/i,
+      /\brabbit\b/i,
+      /\bbunny\b/i,
+      /\bhunt\b/i,
+      /\bbasket\b/i,
+      /🥚/,
+      /🐰/,
+      /🐣/,
+      /\bcockatrice\b/i,
+      /\bbasilisk\b/i
+    ];
+    
+    for (const pattern of forbiddenPatterns) {
+      assert.ok(!pattern.test(handlerContent), `ui-handler.js should not match forbidden pattern: ${pattern}`);
+      assert.ok(!pattern.test(transitionsContent), `state-transitions.js should not match forbidden pattern: ${pattern}`);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Integrates the talent system (merged in PR #111) with the game's handler architecture and level-up progression.

## Changes

### UI Handler (src/handlers/ui-handler.js)
- **VIEW_TALENTS**: Opens talents screen from exploration/battle phases, initializes talentState, saves previousPhase
- **ALLOCATE_TALENT**: Allocates skill points to talents when in talents phase
- **DEALLOCATE_TALENT**: Removes allocated points from talents
- **RESET_TALENTS**: Resets all talent allocations and refunds points
- **CLOSE_TALENTS**: Returns to previous phase or exploration

### State Transitions (src/state-transitions.js)
- Grants **1 skill point per level gained** on level-up
- Initializes talentState if not present
- Accumulates points correctly for multi-level gains

## Testing
- **18 integration tests** covering all handlers and level-up integration
- **Forbidden content checks** for easter egg detection
- All tests passing

## Verification
```bash
node --test tests/talent-handler-integration-test.mjs
# tests 18, pass 18, fail 0
```

## No Easter Eggs
This PR contains no easter eggs - I am a VILLAGER (rolled 6).