### PR TITLE
feat: Talent Tree UI rendering and event handler attachment

### DIFF
--- a/src/render.js
+++ b/src/render.js
@@ -16,6 +16,7 @@ import { renderSettingsPanel, getSettingsStyles, attachSettingsHandlers } from '
 import { renderQuestRewardScreen, renderQuestRewardActions, attachQuestRewardHandlers, getQuestRewardStyles } from './quest-rewards-ui.js';
 import { renderShopPanel, getShopStyles, attachShopHandlers } from './shop-ui.js';
 import { renderCraftingPanel, getCraftingStyles, attachCraftingHandlers } from './crafting-ui.js';
+import { renderTalentTree, getTalentTreeStyles, attachTalentHandlers } from './talents-ui.js';
 import { hasShop } from './shop.js';
 
 function hpLine(entity) {
@@ -122,6 +123,13 @@ export function render(state, dispatch) {
     craftingStyleEl.id = 'crafting-styles';
     craftingStyleEl.textContent = getCraftingStyles();
     document.head.appendChild(craftingStyleEl);
+  }
+
+  if (!document.getElementById('talent-tree-styles')) {
+    const talentStyleEl = document.createElement('style');
+    talentStyleEl.id = 'talent-tree-styles';
+    talentStyleEl.textContent = getTalentTreeStyles();
+    document.head.appendChild(talentStyleEl);
   }
 
   // --- Class Select Phase ---
@@ -819,6 +827,16 @@ export function render(state, dispatch) {
     });
 
     log.innerHTML = state.log.slice().reverse().map(line => `<div class="logLine">${esc(line)}</div>`).join('');
+    return;
+  }
+
+  if (state.phase === 'talents') {
+    const talentHtml = renderTalentTree(state);
+    hud.innerHTML = talentHtml;
+    actions.innerHTML = '<div class="buttons"><button id="btnCloseTalents">Close Talents</button></div>';
+    attachTalentHandlers(hud, dispatch);
+    document.getElementById('btnCloseTalents').onclick = () => dispatch({ type: 'CLOSE_TALENTS' });
+    log.innerHTML = state.log.slice().reverse().map(line => '<div class="logLine">' + esc(line) + '</div>').join('');
     return;
   }
 

--- a/src/talents-ui.js
+++ b/src/talents-ui.js
@@ -471,3 +471,22 @@ export function getTalentTreeStyles() {
     }
   `;
 }
+
+export function attachTalentHandlers(container, dispatch) {
+  container.addEventListener('click', (e) => {
+    const btn = e.target.closest('[data-action]');
+    if (!btn) return;
+    const action = btn.dataset.action;
+    if (action === 'ALLOCATE_TALENT') {
+      const talentId = btn.dataset.talent;
+      if (talentId) dispatch({ type: 'ALLOCATE_TALENT', talentId });
+    } else if (action === 'DEALLOCATE_TALENT') {
+      const talentId = btn.dataset.talent;
+      if (talentId) dispatch({ type: 'DEALLOCATE_TALENT', talentId });
+    } else if (action === 'RESET_TALENTS') {
+      dispatch({ type: 'RESET_TALENTS' });
+    } else if (action === 'CLOSE_TALENTS') {
+      dispatch({ type: 'CLOSE_TALENTS' });
+    }
+  });
+}


### PR DESCRIPTION
## Talent Tree UI Rendering & Handler Attachment

Complements PR #113 (Talent Handler Integration) by adding the missing render.js and talents-ui.js integration.

### Changes
- **src/render.js**: Add talents phase rendering block with style injection, talent tree HTML rendering, and close button
- **src/talents-ui.js**: Add `attachTalentHandlers(container, dispatch)` for delegated click handling of ALLOCATE_TALENT, DEALLOCATE_TALENT, RESET_TALENTS, CLOSE_TALENTS buttons

### Why this is needed
PR #113 added the dispatch handlers (VIEW_TALENTS, ALLOCATE_TALENT, etc.) and level-up skill point integration, but the talent tree screen cannot actually be rendered without these render.js and talents-ui.js changes.

### Testing
- All 53 tests pass (npm run test:all)
- 2 files changed, 37 insertions