### PR TITLE
feat: Add bestiary (monster compendium) module with UI and 32 tests

### DIFF
--- a/src/bestiary-ui.js
+++ b/src/bestiary-ui.js
@@ -1,0 +1,79 @@
+/**
+ * Bestiary UI Module — Renders the monster compendium panel.
+ * Shows encountered enemies, their stats, and defeat counts.
+ */
+
+import {
+  getAllBestiaryEntries,
+  getEncounteredCount,
+  getDefeatedUniqueCount,
+  getCompletionPercent,
+  getTotalEnemyCount,
+} from './bestiary.js';
+
+/**
+ * Render the bestiary panel as an HTML string.
+ * @param {Object} state - Full game state (must include state.bestiary)
+ * @returns {string} HTML string for the bestiary panel
+ */
+export function renderBestiaryPanel(state) {
+  const bestiary = state.bestiary;
+  if (!bestiary) {
+    return '<div class="bestiary-panel"><p>Bestiary not available.</p></div>';
+  }
+
+  const entries = getAllBestiaryEntries(bestiary);
+  const encountered = getEncounteredCount(bestiary);
+  const defeated = getDefeatedUniqueCount(bestiary);
+  const total = getTotalEnemyCount();
+  const percent = getCompletionPercent(bestiary);
+
+  let html = '<div class="bestiary-panel">';
+  html += '<h2>Bestiary</h2>';
+  html += `<div class="bestiary-summary">`;
+  html += `<span>Encountered: ${encountered}/${total}</span>`;
+  html += ` | <span>Defeated: ${defeated}/${total}</span>`;
+  html += ` | <span>Completion: ${percent}%</span>`;
+  html += `</div>`;
+
+  html += '<div class="bestiary-list">';
+
+  for (const entry of entries) {
+    if (!entry.encountered) {
+      html += `<div class="bestiary-entry bestiary-unknown">`;
+      html += `<span class="bestiary-name">???</span>`;
+      html += entry.isBoss ? ' <span class="bestiary-boss-tag">[Boss]</span>' : '';
+      html += `</div>`;
+      continue;
+    }
+
+    const bossTag = entry.isBoss ? ' <span class="bestiary-boss-tag">[Boss]</span>' : '';
+    html += `<div class="bestiary-entry bestiary-known${entry.isBoss ? ' bestiary-boss' : ''}">`;
+    html += `<div class="bestiary-entry-header">`;
+    html += `<span class="bestiary-name">${entry.name}</span>${bossTag}`;
+    html += `<span class="bestiary-element">${entry.element || 'none'}</span>`;
+    html += `</div>`;
+
+    if (entry.description) {
+      html += `<div class="bestiary-description">${entry.description}</div>`;
+    }
+
+    html += `<div class="bestiary-stats">`;
+    html += `HP: ${entry.maxHp} | ATK: ${entry.atk} | DEF: ${entry.def} | SPD: ${entry.spd}`;
+    html += `</div>`;
+    html += `<div class="bestiary-rewards">`;
+    html += `XP: ${entry.xpReward} | Gold: ${entry.goldReward}`;
+    if (entry.phases) {
+      html += ` | Phases: ${entry.phases}`;
+    }
+    html += `</div>`;
+    html += `<div class="bestiary-defeats">Defeated: ${entry.timesDefeated} time${entry.timesDefeated !== 1 ? 's' : ''}</div>`;
+    html += `</div>`;
+  }
+
+  html += '</div>';
+  html += '<button class="bestiary-close-btn" data-action="close-bestiary">Close</button>';
+  html += '</div>';
+
+  return html;
+}

--- a/src/bestiary.js
+++ b/src/bestiary.js
@@ -1,0 +1,198 @@
+/**
+ * Bestiary Module — Monster Compendium
+ * Tracks which enemies the player has encountered and defeated.
+ * Provides lookup of enemy stats, weaknesses, and kill counts.
+ * All functions are pure — they return new state objects.
+ */
+
+import { ENEMIES } from './data/enemies.js';
+import { BOSSES } from './data/bosses.js';
+
+/**
+ * Create the initial bestiary state.
+ * @returns {Object} Empty bestiary state
+ */
+export function createBestiaryState() {
+  return {
+    /** Set of enemy IDs the player has encountered */
+    encountered: [],
+    /** Map of enemy ID -> number of times defeated */
+    defeatedCounts: {},
+  };
+}
+
+/**
+ * Record that the player has encountered an enemy.
+ * @param {Object} bestiary - Current bestiary state
+ * @param {string} enemyId - The enemy identifier
+ * @returns {Object} Updated bestiary state
+ */
+export function recordEncounter(bestiary, enemyId) {
+  if (!enemyId || typeof enemyId !== 'string') return bestiary;
+  if (bestiary.encountered.includes(enemyId)) return bestiary;
+  return {
+    ...bestiary,
+    encountered: [...bestiary.encountered, enemyId],
+  };
+}
+
+/**
+ * Record that the player has defeated an enemy.
+ * Also records the encounter if not already tracked.
+ * @param {Object} bestiary - Current bestiary state
+ * @param {string} enemyId - The enemy identifier
+ * @returns {Object} Updated bestiary state
+ */
+export function recordDefeat(bestiary, enemyId) {
+  if (!enemyId || typeof enemyId !== 'string') return bestiary;
+  const updated = recordEncounter(bestiary, enemyId);
+  const counts = { ...updated.defeatedCounts };
+  counts[enemyId] = (counts[enemyId] || 0) + 1;
+  return {
+    ...updated,
+    defeatedCounts: counts,
+  };
+}
+
+/**
+ * Check if the player has encountered an enemy.
+ * @param {Object} bestiary - Current bestiary state
+ * @param {string} enemyId - The enemy identifier
+ * @returns {boolean}
+ */
+export function hasEncountered(bestiary, enemyId) {
+  return bestiary.encountered.includes(enemyId);
+}
+
+/**
+ * Get the number of times an enemy has been defeated.
+ * @param {Object} bestiary - Current bestiary state
+ * @param {string} enemyId - The enemy identifier
+ * @returns {number}
+ */
+export function getDefeatCount(bestiary, enemyId) {
+  return bestiary.defeatedCounts[enemyId] || 0;
+}
+
+/**
+ * Get total number of unique enemies encountered.
+ * @param {Object} bestiary - Current bestiary state
+ * @returns {number}
+ */
+export function getEncounteredCount(bestiary) {
+  return bestiary.encountered.length;
+}
+
+/**
+ * Get total number of unique enemies defeated at least once.
+ * @param {Object} bestiary - Current bestiary state
+ * @returns {number}
+ */
+export function getDefeatedUniqueCount(bestiary) {
+  return Object.keys(bestiary.defeatedCounts).length;
+}
+
+/**
+ * Get the full bestiary entry for an enemy (stats + player tracking).
+ * Only returns full stats if the enemy has been encountered.
+ * @param {Object} bestiary - Current bestiary state
+ * @param {string} enemyId - The enemy identifier
+ * @returns {Object|null} Bestiary entry or null if unknown
+ */
+export function getBestiaryEntry(bestiary, enemyId) {
+  const enemy = ENEMIES[enemyId];
+  const boss = BOSSES[enemyId];
+
+  if (!enemy && !boss) return null;
+
+  const encountered = hasEncountered(bestiary, enemyId);
+  const timesDefeated = getDefeatCount(bestiary, enemyId);
+
+  if (!encountered) {
+    return {
+      id: enemyId,
+      name: '???',
+      encountered: false,
+      timesDefeated: 0,
+      isBoss: !!boss,
+    };
+  }
+
+  if (boss) {
+    const phase1 = boss.phases[0];
+    return {
+      id: enemyId,
+      name: boss.name,
+      description: boss.description,
+      encountered: true,
+      timesDefeated,
+      isBoss: true,
+      element: boss.element,
+      maxHp: phase1.maxHp,
+      atk: phase1.atk,
+      def: phase1.def,
+      spd: phase1.spd,
+      phases: boss.phases.length,
+      xpReward: boss.xpReward,
+      goldReward: boss.goldReward,
+    };
+  }
+
+  return {
+    id: enemyId,
+    name: enemy.name,
+    encountered: true,
+    timesDefeated,
+    isBoss: false,
+    element: enemy.element,
+    maxHp: enemy.maxHp ?? enemy.hp,
+    atk: enemy.atk,
+    def: enemy.def,
+    spd: enemy.spd,
+    xpReward: enemy.xpReward,
+    goldReward: enemy.goldReward,
+    aiBehavior: enemy.aiBehavior,
+  };
+}
+
+/**
+ * Get all bestiary entries (encountered and unencountered).
+ * Unencountered entries show as '???' with minimal info.
+ * @param {Object} bestiary - Current bestiary state
+ * @returns {Object[]} Array of bestiary entries
+ */
+export function getAllBestiaryEntries(bestiary) {
+  const entries = [];
+
+  // Regular enemies
+  for (const id of Object.keys(ENEMIES)) {
+    entries.push(getBestiaryEntry(bestiary, id));
+  }
+
+  // Boss enemies
+  for (const id of Object.keys(BOSSES)) {
+    entries.push(getBestiaryEntry(bestiary, id));
+  }
+
+  return entries;
+}
+
+/**
+ * Get completion percentage (unique enemies defeated / total enemies).
+ * @param {Object} bestiary - Current bestiary state
+ * @returns {number} Percentage 0-100
+ */
+export function getCompletionPercent(bestiary) {
+  const totalEnemies = Object.keys(ENEMIES).length + Object.keys(BOSSES).length;
+  if (totalEnemies === 0) return 100;
+  const defeated = getDefeatedUniqueCount(bestiary);
+  return Math.round((defeated / totalEnemies) * 100);
+}
+
+/**
+ * Get the total number of enemies in the game (regular + boss).
+ * @returns {number}
+ */
+export function getTotalEnemyCount() {
+  return Object.keys(ENEMIES).length + Object.keys(BOSSES).length;
+}

--- a/tests/bestiary-test.mjs
+++ b/tests/bestiary-test.mjs
@@ -1,0 +1,285 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { ENEMIES } from '../src/data/enemies.js';
+import { BOSSES } from '../src/data/bosses.js';
+import {
+  createBestiaryState,
+  recordEncounter,
+  recordDefeat,
+  hasEncountered,
+  getDefeatCount,
+  getEncounteredCount,
+  getDefeatedUniqueCount,
+  getBestiaryEntry,
+  getAllBestiaryEntries,
+  getCompletionPercent,
+  getTotalEnemyCount,
+} from '../src/bestiary.js';
+
+describe('Bestiary', () => {
+  describe('createBestiaryState', () => {
+    it('should create an empty bestiary state', () => {
+      const state = createBestiaryState();
+      assert.deepStrictEqual(state.encountered, []);
+      assert.deepStrictEqual(state.defeatedCounts, {});
+    });
+  });
+
+  describe('recordEncounter', () => {
+    it('should add a new enemy to encountered list', () => {
+      let bestiary = createBestiaryState();
+      bestiary = recordEncounter(bestiary, 'slime');
+      assert.deepStrictEqual(bestiary.encountered, ['slime']);
+    });
+
+    it('should not duplicate encounters', () => {
+      let bestiary = createBestiaryState();
+      bestiary = recordEncounter(bestiary, 'slime');
+      bestiary = recordEncounter(bestiary, 'slime');
+      assert.deepStrictEqual(bestiary.encountered, ['slime']);
+    });
+
+    it('should track multiple enemies', () => {
+      let bestiary = createBestiaryState();
+      bestiary = recordEncounter(bestiary, 'slime');
+      bestiary = recordEncounter(bestiary, 'goblin');
+      bestiary = recordEncounter(bestiary, 'wolf');
+      assert.equal(bestiary.encountered.length, 3);
+      assert.ok(bestiary.encountered.includes('slime'));
+      assert.ok(bestiary.encountered.includes('goblin'));
+      assert.ok(bestiary.encountered.includes('wolf'));
+    });
+
+    it('should handle invalid input gracefully', () => {
+      let bestiary = createBestiaryState();
+      assert.deepStrictEqual(recordEncounter(bestiary, null), bestiary);
+      assert.deepStrictEqual(recordEncounter(bestiary, ''), bestiary);
+      assert.deepStrictEqual(recordEncounter(bestiary, 123), bestiary);
+    });
+
+    it('should return new state object (immutability)', () => {
+      let bestiary = createBestiaryState();
+      const updated = recordEncounter(bestiary, 'slime');
+      assert.notStrictEqual(bestiary, updated);
+      assert.deepStrictEqual(bestiary.encountered, []);
+    });
+  });
+
+  describe('recordDefeat', () => {
+    it('should record a defeat and auto-encounter', () => {
+      let bestiary = createBestiaryState();
+      bestiary = recordDefeat(bestiary, 'slime');
+      assert.ok(bestiary.encountered.includes('slime'));
+      assert.equal(bestiary.defeatedCounts['slime'], 1);
+    });
+
+    it('should increment defeat count on multiple defeats', () => {
+      let bestiary = createBestiaryState();
+      bestiary = recordDefeat(bestiary, 'goblin');
+      bestiary = recordDefeat(bestiary, 'goblin');
+      bestiary = recordDefeat(bestiary, 'goblin');
+      assert.equal(bestiary.defeatedCounts['goblin'], 3);
+      assert.equal(bestiary.encountered.length, 1);
+    });
+
+    it('should handle invalid input gracefully', () => {
+      let bestiary = createBestiaryState();
+      assert.deepStrictEqual(recordDefeat(bestiary, null), bestiary);
+      assert.deepStrictEqual(recordDefeat(bestiary, ''), bestiary);
+    });
+
+    it('should return new state object (immutability)', () => {
+      let bestiary = createBestiaryState();
+      const updated = recordDefeat(bestiary, 'slime');
+      assert.notStrictEqual(bestiary, updated);
+      assert.deepStrictEqual(bestiary.defeatedCounts, {});
+    });
+  });
+
+  describe('hasEncountered', () => {
+    it('should return false for unencountered enemy', () => {
+      const bestiary = createBestiaryState();
+      assert.equal(hasEncountered(bestiary, 'slime'), false);
+    });
+
+    it('should return true for encountered enemy', () => {
+      let bestiary = createBestiaryState();
+      bestiary = recordEncounter(bestiary, 'slime');
+      assert.equal(hasEncountered(bestiary, 'slime'), true);
+    });
+  });
+
+  describe('getDefeatCount', () => {
+    it('should return 0 for undefeated enemy', () => {
+      const bestiary = createBestiaryState();
+      assert.equal(getDefeatCount(bestiary, 'slime'), 0);
+    });
+
+    it('should return correct defeat count', () => {
+      let bestiary = createBestiaryState();
+      bestiary = recordDefeat(bestiary, 'slime');
+      bestiary = recordDefeat(bestiary, 'slime');
+      assert.equal(getDefeatCount(bestiary, 'slime'), 2);
+    });
+  });
+
+  describe('getEncounteredCount', () => {
+    it('should return 0 for empty bestiary', () => {
+      assert.equal(getEncounteredCount(createBestiaryState()), 0);
+    });
+
+    it('should count unique encounters', () => {
+      let bestiary = createBestiaryState();
+      bestiary = recordEncounter(bestiary, 'slime');
+      bestiary = recordEncounter(bestiary, 'goblin');
+      bestiary = recordDefeat(bestiary, 'wolf');
+      assert.equal(getEncounteredCount(bestiary), 3);
+    });
+  });
+
+  describe('getDefeatedUniqueCount', () => {
+    it('should return 0 for empty bestiary', () => {
+      assert.equal(getDefeatedUniqueCount(createBestiaryState()), 0);
+    });
+
+    it('should count unique defeated enemies', () => {
+      let bestiary = createBestiaryState();
+      bestiary = recordDefeat(bestiary, 'slime');
+      bestiary = recordDefeat(bestiary, 'slime');
+      bestiary = recordDefeat(bestiary, 'goblin');
+      assert.equal(getDefeatedUniqueCount(bestiary), 2);
+    });
+  });
+
+  describe('getBestiaryEntry', () => {
+    it('should return null for nonexistent enemy', () => {
+      const bestiary = createBestiaryState();
+      assert.equal(getBestiaryEntry(bestiary, 'nonexistent'), null);
+    });
+
+    it('should return hidden entry for unencountered enemy', () => {
+      const bestiary = createBestiaryState();
+      const entry = getBestiaryEntry(bestiary, 'slime');
+      assert.equal(entry.name, '???');
+      assert.equal(entry.encountered, false);
+      assert.equal(entry.isBoss, false);
+      assert.equal(entry.timesDefeated, 0);
+    });
+
+    it('should return full stats for encountered regular enemy', () => {
+      let bestiary = createBestiaryState();
+      bestiary = recordEncounter(bestiary, 'slime');
+      const entry = getBestiaryEntry(bestiary, 'slime');
+      assert.equal(entry.name, 'Slime');
+      assert.equal(entry.encountered, true);
+      assert.equal(entry.isBoss, false);
+      assert.equal(entry.element, 'earth');
+      assert.equal(entry.maxHp, 18);
+      assert.equal(entry.atk, 5);
+      assert.equal(entry.def, 2);
+      assert.equal(entry.spd, 4);
+      assert.equal(entry.xpReward, 5);
+      assert.equal(entry.goldReward, 3);
+    });
+
+    it('should show defeat count for defeated enemy', () => {
+      let bestiary = createBestiaryState();
+      bestiary = recordDefeat(bestiary, 'goblin');
+      bestiary = recordDefeat(bestiary, 'goblin');
+      const entry = getBestiaryEntry(bestiary, 'goblin');
+      assert.equal(entry.timesDefeated, 2);
+      assert.equal(entry.encountered, true);
+    });
+
+    it('should return hidden entry for unencountered boss', () => {
+      const bestiary = createBestiaryState();
+      const entry = getBestiaryEntry(bestiary, 'forest-guardian');
+      assert.equal(entry.name, '???');
+      assert.equal(entry.encountered, false);
+      assert.equal(entry.isBoss, true);
+    });
+
+    it('should return full stats for encountered boss', () => {
+      let bestiary = createBestiaryState();
+      bestiary = recordEncounter(bestiary, 'fire-drake');
+      const entry = getBestiaryEntry(bestiary, 'fire-drake');
+      assert.equal(entry.name, 'Fire Drake');
+      assert.equal(entry.encountered, true);
+      assert.equal(entry.isBoss, true);
+      assert.equal(entry.element, 'fire');
+      assert.equal(entry.maxHp, 200);
+      assert.equal(entry.phases, 3);
+      assert.equal(entry.xpReward, 300);
+      assert.equal(entry.goldReward, 200);
+    });
+  });
+
+  describe('getAllBestiaryEntries', () => {
+    it('should return entries for all enemies and bosses', () => {
+      const bestiary = createBestiaryState();
+      const entries = getAllBestiaryEntries(bestiary);
+      const total = getTotalEnemyCount();
+      assert.equal(entries.length, total);
+    });
+
+    it('should show all as hidden when no encounters', () => {
+      const bestiary = createBestiaryState();
+      const entries = getAllBestiaryEntries(bestiary);
+      for (const entry of entries) {
+        assert.equal(entry.encountered, false);
+        assert.equal(entry.name, '???');
+      }
+    });
+
+    it('should include both regular enemies and bosses', () => {
+      let bestiary = createBestiaryState();
+      bestiary = recordEncounter(bestiary, 'slime');
+      bestiary = recordEncounter(bestiary, 'forest-guardian');
+      const entries = getAllBestiaryEntries(bestiary);
+      const slimeEntry = entries.find(e => e.id === 'slime');
+      const bossEntry = entries.find(e => e.id === 'forest-guardian');
+      assert.ok(slimeEntry);
+      assert.ok(bossEntry);
+      assert.equal(slimeEntry.isBoss, false);
+      assert.equal(bossEntry.isBoss, true);
+    });
+  });
+
+  describe('getCompletionPercent', () => {
+    it('should return 0 for empty bestiary', () => {
+      assert.equal(getCompletionPercent(createBestiaryState()), 0);
+    });
+
+    it('should calculate correct percentage', () => {
+      let bestiary = createBestiaryState();
+      const total = getTotalEnemyCount();
+      bestiary = recordDefeat(bestiary, 'slime');
+      const expected = Math.round((1 / total) * 100);
+      assert.equal(getCompletionPercent(bestiary), expected);
+    });
+
+    it('should return 100 when all enemies defeated', () => {
+      let bestiary = createBestiaryState();
+      // Defeat all regular enemies
+      for (const id of Object.keys(ENEMIES)) {
+        bestiary = recordDefeat(bestiary, id);
+      }
+      for (const id of Object.keys(BOSSES)) {
+        bestiary = recordDefeat(bestiary, id);
+      }
+      assert.equal(getCompletionPercent(bestiary), 100);
+    });
+  });
+
+  describe('getTotalEnemyCount', () => {
+    it('should return positive number', () => {
+      assert.ok(getTotalEnemyCount() > 0);
+    });
+
+    it('should include both regular enemies and bosses', () => {
+      // We know there are at least 9 regular enemies and 3 bosses
+      assert.ok(getTotalEnemyCount() >= 12);
+    });
+  });
+});


### PR DESCRIPTION
## Bestiary / Monster Compendium

Adds a new bestiary system that tracks which enemies the player has encountered and defeated.

### New Files
- **src/bestiary.js**: Core bestiary logic — pure functional design
  - `createBestiaryState()` — initializes empty bestiary
  - `recordEncounter()` / `recordDefeat()` — tracks encounters & kills
  - `getBestiaryEntry()` — returns full enemy stats if encountered, ??? if not
  - `getAllBestiaryEntries()` — all enemies + bosses with tracking data
  - `getCompletionPercent()` — tracks % of unique enemies defeated
  - `getTotalEnemyCount()` — counts all regular + boss enemies

- **src/bestiary-ui.js**: Renders bestiary panel
  - Shows encountered/defeated/completion summary
  - Full stats (HP, ATK, DEF, SPD, element, rewards) for encountered enemies
  - Boss entries show phase count and description
  - ??? entries for unencountered enemies

- **tests/bestiary-test.mjs**: 32 comprehensive tests covering all functions
  - Immutability checks, invalid input handling, boss entries, completion %

### Still TODO (follow-up PR)
- Wire bestiary into game state initialization
- Record encounters in `startNewEncounter()`
- Record defeats in `applyVictoryDefeat()`
- Add 'bestiary' game phase and keyboard shortcut
- Save/load bestiary state with save slots

All 32 tests passing. No Easter egg content.