### PR TITLE
feat: Wire bestiary into game state, combat, UI, and rendering

### DIFF
--- a/src/combat.js
+++ b/src/combat.js
@@ -8,6 +8,7 @@ import { StatusEffect } from './combat/status-effects.js';
 import { selectEnemyAction, executeEnemyAbility } from './enemy-abilities.js';
 import { getEffectiveCombatStats } from './combat/equipment-bonuses.js';
 import { getGoldMultiplier, getMpCostMultiplier } from './world-events.js';
+import { recordEncounter, recordDefeat } from './bestiary.js';
 
 // Minimal deterministic RNG (Park-Miller LCG)
 export function nextRng(seed) {
@@ -102,6 +103,7 @@ function applyVictoryDefeat(state) {
         gold: (state.player.gold ?? 0) + goldGained,
       },
     };
+    if (state.bestiary && state.currentEnemyId) { state = { ...state, bestiary: recordDefeat(state.bestiary, state.currentEnemyId) }; }
     state = pushLog(state, `Victory! The ${state.enemy.name} dissolves.`);
   }
   if (state.player.hp <= 0) {
@@ -130,6 +132,7 @@ export function startNewEncounter(state, zoneLevel = 1) {
     turn: 1,
     player: { ...state.player, defending: false, statusEffects: [] },
   };
+  next = { ...next, currentEnemyId: enemyId, bestiary: recordEncounter(next.bestiary || { encountered: [], defeatedCounts: {} }, enemyId) };
 
   next = pushLog(next, `A wild ${enemy.name} appears.`);
   next = pushLog(next, `Your turn.`);

--- a/src/handlers/ui-handler.js
+++ b/src/handlers/ui-handler.js
@@ -349,5 +349,15 @@ export function handleUIAction(state, action) {
     return { ...state, phase: returnPhase };
   }
 
+  // Bestiary
+  if (type === 'VIEW_BESTIARY') {
+    if (state.phase === 'class-select') return null;
+    return { ...state, phase: 'bestiary', previousPhase: state.phase };
+  }
+  if (type === 'CLOSE_BESTIARY') {
+    if (state.phase !== 'bestiary') return null;
+    return { ...state, phase: state.previousPhase || 'exploration' };
+  }
+
   return null;
 }

--- a/src/main.js
+++ b/src/main.js
@@ -77,6 +77,12 @@ window.addEventListener('keydown', (event) => {
     return;
   }
 
+  if (key === 'b' || key === 'B') {
+    event.preventDefault();
+    dispatch({ type: 'VIEW_BESTIARY' });
+    return;
+  }
+
   const direction = keyToCardinalDirection(key);
   if (!direction) return;
 

--- a/src/render.js
+++ b/src/render.js
@@ -21,6 +21,7 @@ import { renderHelpModal, getHelpStyles, attachHelpHandlers } from './help-ui.js
 import { renderWorldEventBanner } from './world-events-ui.js';
 import { isMinimapHidden } from './world-events.js';
 import { hasShop } from './shop.js';
+import { renderBestiaryPanel } from './bestiary-ui.js';
 
 function hpLine(entity) {
   const pct = Math.round((entity.hp / entity.maxHp) * 100);
@@ -985,6 +986,20 @@ export function render(state, dispatch) {
     actions.innerHTML = '<div class="buttons"><button id="btnContinueAfterFlee">Continue Exploring</button></div>';
     document.getElementById('btnContinueAfterFlee').onclick = () => dispatch({ type: 'CONTINUE_AFTER_FLEE' });
     log.innerHTML = state.log.slice().reverse().map((line) => `<div class="logLine">${esc(line)}</div>`).join('');
+    finalizeRender();
+    return;
+  }
+
+  if (state.phase === 'bestiary') {
+    hud.innerHTML = renderBestiaryPanel(state);
+    actions.innerHTML = '<div class="buttons"><button id="btnCloseBestiary">Close Bestiary</button></div>';
+    // Wire close button
+    const closeBtn = document.getElementById('btnCloseBestiary');
+    if (closeBtn) closeBtn.onclick = () => dispatch({ type: 'CLOSE_BESTIARY' });
+    // Also wire data-action close button from bestiary-ui
+    const dataCloseBtn = hud.querySelector('[data-action="close-bestiary"]');
+    if (dataCloseBtn) dataCloseBtn.onclick = () => dispatch({ type: 'CLOSE_BESTIARY' });
+    log.innerHTML = state.log.slice().reverse().map(line => '<div class="logLine">' + esc(line) + '</div>').join('');
     finalizeRender();
     return;
   }

--- a/src/state.js
+++ b/src/state.js
@@ -4,6 +4,7 @@ import { CLASS_DEFINITIONS } from './characters/classes.js';
 import { getEncounter, getEnemy } from './data/enemies.js';
 import { createWorldState } from './map.js';
 import { createWeatherState } from './weather.js';
+import { createBestiaryState } from './bestiary.js';
 
 export function initialState() {
   const playerBase = characters.player;
@@ -37,6 +38,7 @@ export function initialState() {
     ],
     world: createWorldState(),
     weatherState: createWeatherState(),
+    bestiary: createBestiaryState(),
   };
 }
 
@@ -91,6 +93,7 @@ export function initialStateWithClass(classId) {
       `Your turn.`,
     ],
     world: createWorldState(),
+    bestiary: createBestiaryState(),
   };
 }
 

--- a/tests/bestiary-integration-test.mjs
+++ b/tests/bestiary-integration-test.mjs
@@ -1,0 +1,190 @@
+/**
+ * Bestiary Integration Tests
+ * Tests that the bestiary is properly wired into:
+ * - State initialization (initialState, initialStateWithClass)
+ * - Combat encounters (startNewEncounter records encounters)
+ * - Victory (applyVictoryDefeat records defeats via playerAttack)
+ * - UI handler (VIEW_BESTIARY / CLOSE_BESTIARY actions)
+ */
+
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { initialState, initialStateWithClass } from '../src/state.js';
+import { startNewEncounter, playerAttack } from '../src/combat.js';
+import { handleUIAction } from '../src/handlers/ui-handler.js';
+import { createBestiaryState, hasEncountered, getDefeatCount } from '../src/bestiary.js';
+
+describe('Bestiary Integration — State Initialization', () => {
+  it('initialState() includes bestiary', () => {
+    const state = initialState();
+    assert.ok(state.bestiary, 'state.bestiary should exist');
+    assert.ok(Array.isArray(state.bestiary.encountered), 'bestiary.encountered should be an array');
+    assert.deepStrictEqual(state.bestiary.encountered, []);
+    assert.deepStrictEqual(state.bestiary.defeatedCounts, {});
+  });
+
+  it('initialStateWithClass(warrior) includes bestiary', () => {
+    const state = initialStateWithClass('warrior');
+    assert.ok(state.bestiary, 'state.bestiary should exist');
+    assert.ok(Array.isArray(state.bestiary.encountered), 'bestiary.encountered should be an array');
+    assert.deepStrictEqual(state.bestiary.encountered, []);
+    assert.deepStrictEqual(state.bestiary.defeatedCounts, {});
+  });
+
+  it('initialStateWithClass(mage) includes bestiary', () => {
+    const state = initialStateWithClass('mage');
+    assert.ok(state.bestiary, 'state.bestiary should exist');
+    assert.deepStrictEqual(state.bestiary.encountered, []);
+  });
+
+  it('initialStateWithClass(rogue) includes bestiary', () => {
+    const state = initialStateWithClass('rogue');
+    assert.ok(state.bestiary, 'state.bestiary should exist');
+    assert.deepStrictEqual(state.bestiary.encountered, []);
+  });
+
+  it('initialStateWithClass(cleric) includes bestiary', () => {
+    const state = initialStateWithClass('cleric');
+    assert.ok(state.bestiary, 'state.bestiary should exist');
+    assert.deepStrictEqual(state.bestiary.encountered, []);
+  });
+});
+
+describe('Bestiary Integration — Combat Encounter Recording', () => {
+  it('startNewEncounter records the enemy in bestiary.encountered', () => {
+    const state = initialStateWithClass('warrior');
+    const explorationState = { ...state, phase: 'exploration' };
+    const encounterState = startNewEncounter(explorationState, 1);
+    
+    assert.ok(encounterState.bestiary, 'bestiary should still exist after encounter');
+    assert.ok(encounterState.bestiary.encountered.length > 0, 'should have at least one encountered enemy');
+    assert.ok(encounterState.currentEnemyId, 'currentEnemyId should be set');
+    assert.ok(hasEncountered(encounterState.bestiary, encounterState.currentEnemyId),
+      'the encountered enemy should be tracked in bestiary');
+  });
+
+  it('startNewEncounter stores currentEnemyId in state', () => {
+    const state = initialStateWithClass('warrior');
+    const encounterState = startNewEncounter(state, 1);
+    assert.ok(typeof encounterState.currentEnemyId === 'string', 'currentEnemyId should be a string');
+    assert.ok(encounterState.currentEnemyId.length > 0, 'currentEnemyId should not be empty');
+  });
+
+  it('multiple encounters accumulate in bestiary', () => {
+    let state = initialStateWithClass('warrior');
+    for (let i = 0; i < 5; i++) {
+      state = {
+        ...state,
+        phase: 'exploration',
+        rngSeed: (state.rngSeed * 48271) % 2147483647,
+      };
+      state = startNewEncounter(state, 1);
+    }
+    assert.ok(state.bestiary.encountered.length >= 1, 'should have encountered at least one unique enemy');
+  });
+
+  it('startNewEncounter works even without pre-existing bestiary (graceful fallback)', () => {
+    const state = initialStateWithClass('warrior');
+    const noBestiaryState = { ...state, bestiary: undefined };
+    const encounterState = startNewEncounter(noBestiaryState, 1);
+    
+    assert.ok(encounterState.bestiary, 'bestiary should be created from fallback');
+    assert.ok(encounterState.bestiary.encountered.length > 0, 'should have at least one encountered enemy');
+  });
+});
+
+describe('Bestiary Integration — Victory Defeat Recording', () => {
+  it('defeating an enemy records the defeat in bestiary', () => {
+    let state = initialStateWithClass('warrior');
+    state = startNewEncounter(state, 1);
+    const enemyId = state.currentEnemyId;
+    assert.ok(enemyId, 'should have a currentEnemyId');
+    
+    // Set up a scenario where the enemy will die from one hit
+    state = {
+      ...state,
+      enemy: { ...state.enemy, hp: 1, maxHp: 100, def: 0, statusEffects: [] },
+      player: { ...state.player, atk: 999, defending: false, statusEffects: [], equipment: {} },
+      phase: 'player-turn',
+    };
+    
+    const afterAttack = playerAttack(state);
+    
+    if (afterAttack.phase === 'victory') {
+      assert.ok(getDefeatCount(afterAttack.bestiary, enemyId) >= 1,
+        'defeated enemy should have defeat count >= 1');
+    }
+  });
+});
+
+describe('Bestiary Integration — UI Handler Actions', () => {
+  it('VIEW_BESTIARY changes phase to bestiary from exploration', () => {
+    const state = { phase: 'exploration', bestiary: createBestiaryState(), log: [] };
+    const result = handleUIAction(state, { type: 'VIEW_BESTIARY' });
+    assert.ok(result, 'should return a new state');
+    assert.strictEqual(result.phase, 'bestiary');
+    assert.strictEqual(result.previousPhase, 'exploration');
+  });
+
+  it('VIEW_BESTIARY changes phase to bestiary from player-turn', () => {
+    const state = { phase: 'player-turn', bestiary: createBestiaryState(), log: [] };
+    const result = handleUIAction(state, { type: 'VIEW_BESTIARY' });
+    assert.ok(result, 'should return a new state');
+    assert.strictEqual(result.phase, 'bestiary');
+    assert.strictEqual(result.previousPhase, 'player-turn');
+  });
+
+  it('VIEW_BESTIARY returns null during class-select', () => {
+    const state = { phase: 'class-select', log: [] };
+    const result = handleUIAction(state, { type: 'VIEW_BESTIARY' });
+    assert.strictEqual(result, null, 'should return null during class-select');
+  });
+
+  it('CLOSE_BESTIARY returns to previous phase', () => {
+    const state = { phase: 'bestiary', previousPhase: 'exploration', bestiary: createBestiaryState(), log: [] };
+    const result = handleUIAction(state, { type: 'CLOSE_BESTIARY' });
+    assert.ok(result, 'should return a new state');
+    assert.strictEqual(result.phase, 'exploration');
+  });
+
+  it('CLOSE_BESTIARY defaults to exploration if no previousPhase', () => {
+    const state = { phase: 'bestiary', bestiary: createBestiaryState(), log: [] };
+    const result = handleUIAction(state, { type: 'CLOSE_BESTIARY' });
+    assert.ok(result, 'should return a new state');
+    assert.strictEqual(result.phase, 'exploration');
+  });
+
+  it('CLOSE_BESTIARY returns null if not in bestiary phase', () => {
+    const state = { phase: 'exploration', log: [] };
+    const result = handleUIAction(state, { type: 'CLOSE_BESTIARY' });
+    assert.strictEqual(result, null, 'should return null if not in bestiary phase');
+  });
+});
+
+describe('Bestiary Integration — No Easter Eggs', () => {
+  it('no forbidden words in bestiary integration code', async () => {
+    const fs = await import('node:fs');
+    const path = await import('node:path');
+    
+    const filesToCheck = [
+      'src/state.js',
+      'src/combat.js',
+      'src/handlers/ui-handler.js',
+      'src/main.js',
+      'src/render.js',
+    ];
+    
+    const forbidden = ['cockatrice', 'basilisk', 'hidden_message', 'secret_code'];
+    
+    for (const file of filesToCheck) {
+      const filePath = path.join(process.cwd(), file);
+      const content = fs.readFileSync(filePath, 'utf-8').toLowerCase();
+      for (const word of forbidden) {
+        const regex = new RegExp(word, 'i');
+        assert.ok(!regex.test(content), 
+          'Forbidden word "' + word + '" found in ' + file);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Wires the bestiary module (PR #128) into the full game loop.

### Changes
- **State initialization**: Add `bestiary: createBestiaryState()` to both `initialState()` and `initialStateWithClass()` in state.js
- **Combat encounter recording**: `startNewEncounter()` now calls `recordEncounter()` and stores `currentEnemyId` in state
- **Victory defeat recording**: `applyVictoryDefeat()` now calls `recordDefeat()` when enemy HP reaches 0
- **UI handler**: Added `VIEW_BESTIARY` and `CLOSE_BESTIARY` actions in ui-handler.js
- **Keyboard shortcut**: Press `B` key to open bestiary panel
- **Render phase**: Added bestiary phase rendering with close button support

### Tests
- 17 new integration tests covering all wiring points
- All existing tests still passing (54 in test:all)
- Easter egg scan: CLEAN

### Files Modified
- `src/state.js` - bestiary state initialization
- `src/combat.js` - encounter/defeat recording
- `src/handlers/ui-handler.js` - bestiary UI actions
- `src/main.js` - B key shortcut
- `src/render.js` - bestiary phase rendering
- `tests/bestiary-integration-test.mjs` - 17 integration tests (NEW)