### PR TITLE
feat: NPC Relationships Module with reputation tracking

### DIFF
--- a/src/npc-relationships.js
+++ b/src/npc-relationships.js
@@ -1,0 +1,299 @@
+/**
+ * NPC Relationships Module — AI Village RPG
+ * Owner: Claude Opus 4.5
+ *
+ * Tracks player relationships and reputation with NPCs.
+ * Supports relationship levels, dialogue history, and reputation effects on interactions.
+ */
+
+export const RelationshipLevel = Object.freeze({
+  HOSTILE: 'HOSTILE',
+  UNFRIENDLY: 'UNFRIENDLY',
+  NEUTRAL: 'NEUTRAL',
+  FRIENDLY: 'FRIENDLY',
+  ALLIED: 'ALLIED'
+});
+
+export const ReputationEvent = Object.freeze({
+  QUEST_COMPLETE: { type: 'QUEST_COMPLETE', value: 15 },
+  QUEST_FAIL: { type: 'QUEST_FAIL', value: -20 },
+  GIFT_GIVEN: { type: 'GIFT_GIVEN', minValue: 5, maxValue: 15 },
+  HELPED_NPC: { type: 'HELPED_NPC', value: 10 },
+  BETRAYED_NPC: { type: 'BETRAYED_NPC', value: -30 },
+  DIALOGUE_POSITIVE: { type: 'DIALOGUE_POSITIVE', value: 3 },
+  DIALOGUE_NEGATIVE: { type: 'DIALOGUE_NEGATIVE', value: -5 },
+  COMBAT_VICTORY: { type: 'COMBAT_VICTORY', value: 2 },
+  THEFT_CAUGHT: { type: 'THEFT_CAUGHT', value: -25 }
+});
+
+const LEVEL_THRESHOLDS = [
+  { level: RelationshipLevel.HOSTILE, min: -100, max: -50 },
+  { level: RelationshipLevel.UNFRIENDLY, min: -49, max: -10 },
+  { level: RelationshipLevel.NEUTRAL, min: -9, max: 9 },
+  { level: RelationshipLevel.FRIENDLY, min: 10, max: 49 },
+  { level: RelationshipLevel.ALLIED, min: 50, max: 100 }
+];
+
+/**
+ * @typedef {Object} ConversationEntry
+ * @property {string} dialogId
+ * @property {string} nodeId
+ * @property {string|Object} choice
+ * @property {number} timestamp
+ * @property {string|undefined} topicId
+ */
+
+/**
+ * @typedef {Object} RelationshipRecord
+ * @property {number} reputation
+ * @property {string} level
+ * @property {Array<Object>} history
+ * @property {number|null} lastInteraction
+ * @property {ConversationEntry[]} conversationMemory
+ * @property {Array<Object>} gifts
+ * @property {Array<Object>} questsCompleted
+ */
+
+/**
+ * Manages NPC reputation, relationship levels, and dialogue memory.
+ */
+export class NPCRelationshipManager {
+  constructor() {
+    this.relationships = new Map();
+  }
+
+  /**
+   * Retrieve or create the relationship record for an NPC.
+   * @param {string} npcId - Unique identifier for the NPC.
+   * @returns {RelationshipRecord} Relationship data for the NPC.
+   */
+  getRelationship(npcId) {
+    if (!npcId) {
+      throw new Error('npcId is required to access relationship data.');
+    }
+    if (!this.relationships.has(npcId)) {
+      this.relationships.set(npcId, this._createDefaultRelationship());
+    }
+    return this.relationships.get(npcId);
+  }
+
+  /**
+   * Adjust an NPC's reputation, clamp to range, update level, and log history.
+   * @param {string} npcId - Target NPC.
+   * @param {number} amount - Reputation delta (positive or negative).
+   * @param {string|Object} reason - Description or event for the change.
+   * @returns {RelationshipRecord} Updated relationship record.
+   */
+  modifyReputation(npcId, amount, reason) {
+    const relationship = this.getRelationship(npcId);
+    const timestamp = Date.now();
+    const fromReputation = relationship.reputation;
+    const toReputation = this._clampReputation(fromReputation + amount);
+    const nextLevel = this.getRelationshipLevelForValue(toReputation);
+
+    relationship.reputation = toReputation;
+    relationship.level = nextLevel;
+    relationship.lastInteraction = timestamp;
+    relationship.history.push({
+      timestamp,
+      change: amount,
+      reason: this._extractReason(reason),
+      from: fromReputation,
+      to: toReputation,
+      level: nextLevel
+    });
+
+    return relationship;
+  }
+
+  /**
+   * Get the RelationshipLevel for the NPC based on current reputation.
+   * @param {string} npcId - Target NPC.
+   * @returns {string} RelationshipLevel value.
+   */
+  getRelationshipLevel(npcId) {
+    const relationship = this.getRelationship(npcId);
+    relationship.level = this.getRelationshipLevelForValue(relationship.reputation);
+    return relationship.level;
+  }
+
+  /**
+   * Add a conversation memory entry, keeping the most recent 20.
+   * @param {string} npcId - Target NPC.
+   * @param {string} dialogId - Dialogue identifier.
+   * @param {string} nodeId - Dialogue node identifier.
+   * @param {string|Object} choice - Player choice or option metadata.
+   * @param {number} [timestamp=Date.now()] - When the conversation happened.
+   */
+  addConversationMemory(npcId, dialogId, nodeId, choice, timestamp = Date.now()) {
+    const relationship = this.getRelationship(npcId);
+    const topicId = this._extractTopicId(nodeId, choice);
+    relationship.conversationMemory.push({ dialogId, nodeId, choice, timestamp, topicId });
+    if (relationship.conversationMemory.length > 20) {
+      relationship.conversationMemory = relationship.conversationMemory.slice(-20);
+    }
+    relationship.lastInteraction = timestamp;
+  }
+
+  /**
+   * Get the conversation history for an NPC.
+   * @param {string} npcId - Target NPC.
+   * @returns {ConversationEntry[]} Array of recent conversation entries.
+   */
+  getConversationMemory(npcId) {
+    const relationship = this.getRelationship(npcId);
+    return relationship.conversationMemory;
+  }
+
+  /**
+   * Check if the player discussed a specific topic with an NPC.
+   * @param {string} npcId - Target NPC.
+   * @param {string} topicId - Topic identifier to search for.
+   * @returns {boolean} True if the topic was discussed.
+   */
+  hasDiscussedTopic(npcId, topicId) {
+    const relationship = this.getRelationship(npcId);
+    return relationship.conversationMemory.some(entry =>
+      entry.topicId === topicId ||
+      entry.nodeId === topicId ||
+      entry.choice === topicId ||
+      (entry.choice && typeof entry.choice === 'object' && (entry.choice.topicId === topicId || entry.choice.id === topicId))
+    );
+  }
+
+  /**
+   * Record a gift to an NPC and update reputation based on value.
+   * @param {string} npcId - Target NPC.
+   * @param {string} itemId - Gifted item identifier.
+   * @param {number} value - Value of the gift.
+   * @returns {RelationshipRecord} Updated relationship record.
+   */
+  recordGift(npcId, itemId, value) {
+    const delta = value > 100 ? 15 : value > 50 ? 10 : 5;
+    const relationship = this.getRelationship(npcId);
+    relationship.gifts.push({ itemId, value, timestamp: Date.now(), delta });
+    return this.modifyReputation(npcId, delta, ReputationEvent.GIFT_GIVEN.type);
+  }
+
+  /**
+   * Record a completed quest and adjust reputation.
+   * @param {string} npcId - Target NPC.
+   * @param {string} questId - Completed quest identifier.
+   * @returns {RelationshipRecord} Updated relationship record.
+   */
+  recordQuestComplete(npcId, questId) {
+    const relationship = this.getRelationship(npcId);
+    if (!relationship.questsCompleted.includes(questId)) {
+      relationship.questsCompleted.push(questId);
+    }
+    return this.modifyReputation(npcId, ReputationEvent.QUEST_COMPLETE.value, ReputationEvent.QUEST_COMPLETE.type);
+  }
+
+  /**
+   * Record a failed quest and adjust reputation.
+   * @param {string} npcId - Target NPC.
+   * @param {string} questId - Failed quest identifier.
+   * @returns {RelationshipRecord} Updated relationship record.
+   */
+  recordQuestFail(npcId, questId) {
+    const relationship = this.getRelationship(npcId);
+    if (!relationship.questsCompleted.includes(questId)) {
+      relationship.questsCompleted = relationship.questsCompleted.filter(id => id !== questId);
+    }
+    return this.modifyReputation(npcId, ReputationEvent.QUEST_FAIL.value, ReputationEvent.QUEST_FAIL.type);
+  }
+
+  /**
+   * Get the full reputation history for an NPC.
+   * @param {string} npcId - Target NPC.
+   * @returns {Array<Object>} History entries.
+   */
+  getRelationshipHistory(npcId) {
+    const relationship = this.getRelationship(npcId);
+    return relationship.history;
+  }
+
+  /**
+   * Get a serializable snapshot of all NPC relationships.
+   * @returns {Object} Serializable state.
+   */
+  getState() {
+    return {
+      relationships: Array.from(this.relationships.entries())
+    };
+  }
+
+  /**
+   * Restore relationship state from a serialized snapshot.
+   * @param {Object} state - Saved state to restore from.
+   */
+  restoreState(state) {
+    this.relationships = new Map();
+    if (!state || !Array.isArray(state.relationships)) {
+      return;
+    }
+    for (const [npcId, stored] of state.relationships) {
+      const record = this._createDefaultRelationship();
+      record.reputation = this._clampReputation(typeof stored.reputation === 'number' ? stored.reputation : record.reputation);
+      record.level = this.getRelationshipLevelForValue(record.reputation);
+      record.history = Array.isArray(stored.history) ? [...stored.history] : record.history;
+      record.lastInteraction = typeof stored.lastInteraction === 'number' ? stored.lastInteraction : record.lastInteraction;
+      record.conversationMemory = Array.isArray(stored.conversationMemory)
+        ? stored.conversationMemory.slice(-20)
+        : record.conversationMemory;
+      record.gifts = Array.isArray(stored.gifts) ? [...stored.gifts] : record.gifts;
+      record.questsCompleted = Array.isArray(stored.questsCompleted) ? [...stored.questsCompleted] : record.questsCompleted;
+      this.relationships.set(npcId, record);
+    }
+  }
+
+  /**
+   * Determine the RelationshipLevel for a reputation value.
+   * @param {number} reputation - Reputation score between -100 and 100.
+   * @returns {string} RelationshipLevel value.
+   */
+  getRelationshipLevelForValue(reputation) {
+    const clamped = this._clampReputation(reputation);
+    const match = LEVEL_THRESHOLDS.find(range => clamped >= range.min && clamped <= range.max);
+    return match ? match.level : RelationshipLevel.NEUTRAL;
+  }
+
+  _createDefaultRelationship() {
+    return {
+      reputation: 0,
+      level: RelationshipLevel.NEUTRAL,
+      history: [],
+      lastInteraction: null,
+      conversationMemory: [],
+      gifts: [],
+      questsCompleted: []
+    };
+  }
+
+  _clampReputation(value) {
+    return Math.max(-100, Math.min(100, value));
+  }
+
+  _extractReason(reason) {
+    if (reason && typeof reason === 'object' && 'type' in reason) {
+      return reason.type;
+    }
+    return reason || 'UNKNOWN';
+  }
+
+  _extractTopicId(nodeId, choice) {
+    if (choice && typeof choice === 'object') {
+      if (choice.topicId) return choice.topicId;
+      if (choice.id) return choice.id;
+    }
+    return nodeId;
+  }
+}
+
+/**
+ * Factory for NPCRelationshipManager.
+ * @returns {NPCRelationshipManager} New relationship manager instance.
+ */
+export function createNPCRelationshipManager() {
+  return new NPCRelationshipManager();
+}

--- a/tests/npc-relationships-test.mjs
+++ b/tests/npc-relationships-test.mjs
@@ -1,0 +1,350 @@
+import { describe, test } from 'node:test';
+import assert from 'node:assert';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  NPCRelationshipManager,
+  RelationshipLevel,
+  ReputationEvent,
+} from '../src/npc-relationships.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const MODULE_PATH = path.join(__dirname, '..', 'src', 'npc-relationships.js');
+
+const createManager = () => new NPCRelationshipManager();
+
+describe('NPCRelationshipManager', () => {
+  describe('Constants', () => {
+    test('RelationshipLevel constants include all levels', () => {
+      const expected = {
+        HOSTILE: 'HOSTILE',
+        UNFRIENDLY: 'UNFRIENDLY',
+        NEUTRAL: 'NEUTRAL',
+        FRIENDLY: 'FRIENDLY',
+        ALLIED: 'ALLIED',
+      };
+      assert.deepStrictEqual(RelationshipLevel, expected);
+      assert.strictEqual(Object.keys(RelationshipLevel).length, 5);
+    });
+
+    test('ReputationEvent constants include all events with correct values', () => {
+      const expected = {
+        QUEST_COMPLETE: { type: 'QUEST_COMPLETE', value: 15 },
+        QUEST_FAIL: { type: 'QUEST_FAIL', value: -20 },
+        GIFT_GIVEN: { type: 'GIFT_GIVEN', minValue: 5, maxValue: 15 },
+        HELPED_NPC: { type: 'HELPED_NPC', value: 10 },
+        BETRAYED_NPC: { type: 'BETRAYED_NPC', value: -30 },
+        DIALOGUE_POSITIVE: { type: 'DIALOGUE_POSITIVE', value: 3 },
+        DIALOGUE_NEGATIVE: { type: 'DIALOGUE_NEGATIVE', value: -5 },
+        COMBAT_VICTORY: { type: 'COMBAT_VICTORY', value: 2 },
+        THEFT_CAUGHT: { type: 'THEFT_CAUGHT', value: -25 },
+      };
+      assert.deepStrictEqual(ReputationEvent, expected);
+      assert.strictEqual(Object.keys(ReputationEvent).length, 9);
+    });
+  });
+
+  describe('getRelationship', () => {
+    test('creates a default relationship record', () => {
+      const manager = createManager();
+      const relationship = manager.getRelationship('npc-1');
+
+      assert.strictEqual(relationship.reputation, 0);
+      assert.strictEqual(relationship.level, RelationshipLevel.NEUTRAL);
+      assert.deepStrictEqual(relationship.history, []);
+      assert.strictEqual(relationship.lastInteraction, null);
+      assert.deepStrictEqual(relationship.conversationMemory, []);
+      assert.deepStrictEqual(relationship.gifts, []);
+      assert.deepStrictEqual(relationship.questsCompleted, []);
+    });
+
+    test('throws when npcId is null or undefined', () => {
+      const manager = createManager();
+      assert.throws(() => manager.getRelationship(null));
+      assert.throws(() => manager.getRelationship(undefined));
+    });
+  });
+
+  describe('modifyReputation', () => {
+    test('increases reputation and updates level', () => {
+      const manager = createManager();
+      const updated = manager.modifyReputation('npc-2', 20, 'quest');
+
+      assert.strictEqual(updated.reputation, 20);
+      assert.strictEqual(updated.level, RelationshipLevel.FRIENDLY);
+    });
+
+    test('decreases reputation and updates level', () => {
+      const manager = createManager();
+      const updated = manager.modifyReputation('npc-3', -20, 'insult');
+
+      assert.strictEqual(updated.reputation, -20);
+      assert.strictEqual(updated.level, RelationshipLevel.UNFRIENDLY);
+    });
+
+    test('clamps reputation to a minimum of -100', () => {
+      const manager = createManager();
+      const updated = manager.modifyReputation('npc-4', -200, 'betrayal');
+
+      assert.strictEqual(updated.reputation, -100);
+      assert.strictEqual(updated.level, RelationshipLevel.HOSTILE);
+    });
+
+    test('clamps reputation to a maximum of +100', () => {
+      const manager = createManager();
+      const updated = manager.modifyReputation('npc-5', 200, 'heroics');
+
+      assert.strictEqual(updated.reputation, 100);
+      assert.strictEqual(updated.level, RelationshipLevel.ALLIED);
+    });
+
+    test('logs history with correct from/to/change/reason and timestamp', () => {
+      const manager = createManager();
+      const fakeNow = 1_700_000_000_000;
+      const originalNow = Date.now;
+      Date.now = () => fakeNow;
+
+      try {
+        const updated = manager.modifyReputation('npc-6', 5, { type: 'DIALOGUE_POSITIVE', extra: true });
+        assert.strictEqual(updated.history.length, 1);
+        const entry = updated.history[0];
+        assert.strictEqual(entry.timestamp, fakeNow);
+        assert.strictEqual(entry.change, 5);
+        assert.strictEqual(entry.reason, 'DIALOGUE_POSITIVE');
+        assert.strictEqual(entry.from, 0);
+        assert.strictEqual(entry.to, 5);
+        assert.strictEqual(entry.level, RelationshipLevel.NEUTRAL);
+        assert.strictEqual(updated.lastInteraction, fakeNow);
+      } finally {
+        Date.now = originalNow;
+      }
+    });
+  });
+
+  describe('getRelationshipLevel', () => {
+    test('returns correct level at boundary reputation values', () => {
+      const manager = createManager();
+      const rel = manager.getRelationship('npc-7');
+
+      rel.reputation = -50;
+      assert.strictEqual(manager.getRelationshipLevel('npc-7'), RelationshipLevel.HOSTILE);
+
+      rel.reputation = -10;
+      assert.strictEqual(manager.getRelationshipLevel('npc-7'), RelationshipLevel.UNFRIENDLY);
+
+      rel.reputation = 0;
+      assert.strictEqual(manager.getRelationshipLevel('npc-7'), RelationshipLevel.NEUTRAL);
+
+      rel.reputation = 10;
+      assert.strictEqual(manager.getRelationshipLevel('npc-7'), RelationshipLevel.FRIENDLY);
+
+      rel.reputation = 50;
+      assert.strictEqual(manager.getRelationshipLevel('npc-7'), RelationshipLevel.ALLIED);
+    });
+  });
+
+  describe('Conversation memory', () => {
+    test('stores conversation entry with all fields', () => {
+      const manager = createManager();
+      const timestamp = 12345;
+      manager.addConversationMemory('npc-8', 'dialog-1', 'node-1', { topicId: 'topic-1', text: 'Hello' }, timestamp);
+      const relationship = manager.getRelationship('npc-8');
+      const entry = relationship.conversationMemory[0];
+
+      assert.deepStrictEqual(entry, {
+        dialogId: 'dialog-1',
+        nodeId: 'node-1',
+        choice: { topicId: 'topic-1', text: 'Hello' },
+        timestamp,
+        topicId: 'topic-1',
+      });
+    });
+
+    test('keeps only the 20 most recent conversation entries', () => {
+      const manager = createManager();
+      for (let i = 0; i < 25; i++) {
+        manager.addConversationMemory('npc-9', `dialog-${i}`, `node-${i}`, `choice-${i}`, i);
+      }
+      const memory = manager.getConversationMemory('npc-9');
+
+      assert.strictEqual(memory.length, 20);
+      assert.strictEqual(memory[0].nodeId, 'node-5');
+      assert.strictEqual(memory[memory.length - 1].nodeId, 'node-24');
+    });
+
+    test('returns conversation history array', () => {
+      const manager = createManager();
+      manager.addConversationMemory('npc-10', 'dialog-x', 'node-x', 'choice-x', 10);
+      const relationship = manager.getRelationship('npc-10');
+      const memory = manager.getConversationMemory('npc-10');
+
+      assert.strictEqual(memory, relationship.conversationMemory);
+      assert.strictEqual(memory.length, 1);
+    });
+
+    test('hasDiscussedTopic returns true when topic was discussed', () => {
+      const manager = createManager();
+      manager.addConversationMemory('npc-11', 'dialog-y', 'node-y', { topicId: 'topic-yes', id: 'c1' }, 20);
+
+      assert.strictEqual(manager.hasDiscussedTopic('npc-11', 'topic-yes'), true);
+    });
+
+    test('hasDiscussedTopic returns false when topic was not discussed', () => {
+      const manager = createManager();
+      manager.addConversationMemory('npc-12', 'dialog-z', 'node-z', { topicId: 'topic-other' }, 30);
+
+      assert.strictEqual(manager.hasDiscussedTopic('npc-12', 'topic-missing'), false);
+    });
+  });
+
+  describe('Gifts and quests', () => {
+    test('recordGift applies +5 reputation for low value gifts', () => {
+      const manager = createManager();
+      const relationship = manager.recordGift('npc-13', 'apple', 30);
+
+      assert.strictEqual(relationship.reputation, 5);
+      assert.strictEqual(relationship.level, RelationshipLevel.NEUTRAL);
+      assert.strictEqual(relationship.gifts[0].delta, 5);
+    });
+
+    test('recordGift applies +10 reputation for medium value gifts', () => {
+      const manager = createManager();
+      const relationship = manager.recordGift('npc-14', 'bouquet', 75);
+
+      assert.strictEqual(relationship.reputation, 10);
+      assert.strictEqual(relationship.level, RelationshipLevel.FRIENDLY);
+      assert.strictEqual(relationship.gifts[0].delta, 10);
+    });
+
+    test('recordGift applies +15 reputation for high value gifts', () => {
+      const manager = createManager();
+      const relationship = manager.recordGift('npc-15', 'artifact', 150);
+
+      assert.strictEqual(relationship.reputation, 15);
+      assert.strictEqual(relationship.level, RelationshipLevel.FRIENDLY);
+      assert.strictEqual(relationship.gifts[0].delta, 15);
+    });
+
+    test('recordQuestComplete adds reputation and records quest id', () => {
+      const manager = createManager();
+      const relationship = manager.recordQuestComplete('npc-16', 'quest-1');
+      manager.recordQuestComplete('npc-16', 'quest-1');
+
+      assert.strictEqual(relationship.reputation, 30);
+      assert.strictEqual(relationship.level, RelationshipLevel.FRIENDLY);
+      assert.deepStrictEqual(relationship.questsCompleted, ['quest-1']);
+    });
+
+    test('recordQuestFail subtracts reputation', () => {
+      const manager = createManager();
+      const relationship = manager.recordQuestFail('npc-17', 'quest-2');
+
+      assert.strictEqual(relationship.reputation, -20);
+      assert.strictEqual(relationship.level, RelationshipLevel.UNFRIENDLY);
+    });
+  });
+
+  describe('State management', () => {
+    test('getState returns serializable state', () => {
+      const manager = createManager();
+      manager.modifyReputation('npc-18', 10, 'greet');
+      manager.addConversationMemory('npc-18', 'dialog-a', 'node-a', 'choice-a', 1);
+      const state = manager.getState();
+
+      assert.ok(Array.isArray(state.relationships));
+      assert.ok(state.relationships[0][0]);
+      assert.doesNotThrow(() => JSON.parse(JSON.stringify(state)));
+    });
+
+    test('restoreState rebuilds relationships from saved state', () => {
+      const storedHistory = [{ timestamp: 1, change: 5, reason: 'test', from: 0, to: 5, level: RelationshipLevel.NEUTRAL }];
+      const storedConversation = Array.from({ length: 22 }, (_, i) => ({
+        dialogId: `d-${i}`,
+        nodeId: `n-${i}`,
+        choice: `c-${i}`,
+        timestamp: i,
+      }));
+      const savedState = {
+        relationships: [
+          ['npc-19', {
+            reputation: 120,
+            history: storedHistory,
+            lastInteraction: 999,
+            conversationMemory: storedConversation,
+            gifts: [{ itemId: 'gift', value: 10 }],
+            questsCompleted: ['quest-a'],
+          }],
+          ['npc-20', {
+            reputation: -80,
+            history: [],
+            lastInteraction: null,
+            conversationMemory: [],
+            gifts: [],
+            questsCompleted: [],
+          }],
+        ],
+      };
+
+      const manager = createManager();
+      manager.restoreState(savedState);
+
+      const rel1 = manager.getRelationship('npc-19');
+      assert.strictEqual(rel1.reputation, 100);
+      assert.strictEqual(rel1.level, RelationshipLevel.ALLIED);
+      assert.deepStrictEqual(rel1.history, storedHistory);
+      assert.strictEqual(rel1.lastInteraction, 999);
+      assert.strictEqual(rel1.conversationMemory.length, 20);
+      assert.strictEqual(rel1.conversationMemory[0].nodeId, 'n-2');
+      assert.deepStrictEqual(rel1.gifts, [{ itemId: 'gift', value: 10 }]);
+      assert.deepStrictEqual(rel1.questsCompleted, ['quest-a']);
+
+      const rel2 = manager.getRelationship('npc-20');
+      assert.strictEqual(rel2.reputation, -80);
+      assert.strictEqual(rel2.level, RelationshipLevel.HOSTILE);
+    });
+  });
+
+  describe('Level transitions', () => {
+    test('reputation transition from NEUTRAL to FRIENDLY (0 to 10)', () => {
+      const manager = createManager();
+      const updated = manager.modifyReputation('npc-21', 10, 'assist');
+
+      assert.strictEqual(updated.reputation, 10);
+      assert.strictEqual(updated.level, RelationshipLevel.FRIENDLY);
+    });
+
+    test('reputation transition from NEUTRAL to UNFRIENDLY (0 to -10)', () => {
+      const manager = createManager();
+      const updated = manager.modifyReputation('npc-22', -10, 'insult');
+
+      assert.strictEqual(updated.reputation, -10);
+      assert.strictEqual(updated.level, RelationshipLevel.UNFRIENDLY);
+    });
+  });
+
+  describe('Forbidden motifs', () => {
+    test('module does not contain easter egg motifs', () => {
+      const bannedWords = [
+        'egg',
+        'easter',
+        'yolk',
+        'omelet',
+        'omelette',
+        'bunny',
+        'rabbit',
+        'chick',
+        'basket',
+        'cockatrice',
+        'basilisk',
+      ];
+      const fileText = fs.readFileSync(MODULE_PATH, 'utf8');
+
+      for (const word of bannedWords) {
+        const regex = new RegExp(`\\b${word}\\b`, 'i');
+        assert.ok(!regex.test(fileText), `Forbidden motif detected: ${word}`);
+      }
+    });
+  });
+});


### PR DESCRIPTION
## NPC Relationships Module — AI Village RPG
**Owner:** Claude Opus 4.5

### Summary
Adds comprehensive NPC relationship/reputation tracking system that complements the existing story/dialog module (PR #12) and the newly-merged Journal System (PR #135).

### New Files
- **src/npc-relationships.js** (299 lines)
- **tests/npc-relationships-test.mjs** (350 lines, 25 tests)

### Features

#### Relationship Levels
- HOSTILE (-100 to -50)
- UNFRIENDLY (-49 to -10)
- NEUTRAL (-9 to +9) — default
- FRIENDLY (+10 to +49)
- ALLIED (+50 to +100)

#### Reputation Events
| Event | Value |
|-------|-------|
| QUEST_COMPLETE | +15 |
| QUEST_FAIL | -20 |
| GIFT_GIVEN | +5/+10/+15 (based on value) |
| HELPED_NPC | +10 |
| BETRAYED_NPC | -30 |
| DIALOGUE_POSITIVE | +3 |
| DIALOGUE_NEGATIVE | -5 |
| COMBAT_VICTORY | +2 |
| THEFT_CAUGHT | -25 |

#### NPCRelationshipManager API
- `getRelationship(npcId)` — Get/create relationship record
- `modifyReputation(npcId, amount, reason)` — Adjust rep with clamping
- `getRelationshipLevel(npcId)` — Current level based on reputation
- `addConversationMemory(npcId, dialogId, nodeId, choice, timestamp)` — Track up to 20 recent conversations
- `hasDiscussedTopic(npcId, topicId)` — Check if topic was discussed (for dialog branching)
- `recordGift(npcId, itemId, value)` — Track gifts (+5/+10/+15 based on value)
- `recordQuestComplete/recordQuestFail(npcId, questId)` — Quest tracking
- `getState()/restoreState(state)` — Save/load support

### Tests (25 total)
- Constants verification
- Reputation modification and clamping (-100 to +100)
- Level transitions at boundary values
- Conversation memory limits (20 max)
- Gift value tiers
- State persistence and restoration
- ✅ Forbidden motifs check (no easter eggs)

### Integration
- Builds on existing story/dialog module (PR #12)
- Complements Journal System (PR #135, now merged)
- Ready for integration with dialog trees for relationship-based branching

### Tests
All 25 new tests pass ✅
Full test suite passes ✅