### PR TITLE
feat: loyalty-based dialog branching - companionLoyalty condition type for RelationshipDialogManager

### DIFF
--- a/src/companion-loyalty-events.js
+++ b/src/companion-loyalty-events.js
@@ -20,6 +20,20 @@ export const LOYALTY_TIERS = [
   { name: 'Soulbound',   threshold: 100, label: 'Unbreakable bond' },
 ];
 
+/** Ordered tier names (ascending) — single source of truth for tier comparisons. */
+export const LOYALTY_TIER_ORDER = LOYALTY_TIERS.map(t => t.name);
+
+/**
+ * Get the index of the loyalty tier for a given loyalty value.
+ * Uses LOYALTY_TIER_ORDER as the single source of truth.
+ * @param {number} loyalty - Current loyalty (0-100).
+ * @returns {number} Tier index (0 = Abandoned, 5 = Soulbound).
+ */
+export function getLoyaltyTierIndex(loyalty) {
+  const tier = getLoyaltyTier(loyalty);
+  return LOYALTY_TIER_ORDER.indexOf(tier.name);
+}
+
 /**
  * Get the loyalty tier for a given loyalty value.
  * @param {number} loyalty - Current loyalty (0-100).

--- a/src/relationship-dialog.js
+++ b/src/relationship-dialog.js
@@ -6,6 +6,8 @@
  */
 
 import { RelationshipLevel, NPCRelationshipManager } from './npc-relationships.js';
+import { LOYALTY_TIER_ORDER, getLoyaltyTier, getLoyaltyTierIndex } from './companion-loyalty-events.js';
+import { getCompanionById } from './companions.js';
 import { DialogManager, conditionalNode } from './story/dialog.js';
 
 export const RELATIONSHIP_LEVEL_ORDER = [
@@ -26,6 +28,31 @@ export const RELATIONSHIP_LEVEL_ORDER = [
 function compareRelationshipLevels(currentLevel, targetLevel, operator) {
   const currentIndex = RELATIONSHIP_LEVEL_ORDER.indexOf(currentLevel);
   const targetIndex = RELATIONSHIP_LEVEL_ORDER.indexOf(targetLevel);
+  if (currentIndex === -1 || targetIndex === -1) {
+    return false;
+  }
+  switch (operator) {
+    case '==': return currentIndex === targetIndex;
+    case '!=': return currentIndex !== targetIndex;
+    case '>': return currentIndex > targetIndex;
+    case '>=': return currentIndex >= targetIndex;
+    case '<': return currentIndex < targetIndex;
+    case '<=': return currentIndex <= targetIndex;
+    default: return currentIndex === targetIndex;
+  }
+}
+
+/**
+ * Compare a companion's current loyalty tier against a target tier.
+ * Uses LOYALTY_TIER_ORDER from companion-loyalty-events as single source of truth.
+ * @param {number} loyalty - Current loyalty value (0-100).
+ * @param {string} targetTier - Target tier name (e.g. 'Devoted', 'Soulbound').
+ * @param {string} operator - Comparison operator (==, !=, >, >=, <, <=).
+ * @returns {boolean} True if the comparison passes.
+ */
+function compareLoyaltyTiers(loyalty, targetTier, operator) {
+  const currentIndex = getLoyaltyTierIndex(loyalty);
+  const targetIndex = LOYALTY_TIER_ORDER.indexOf(targetTier);
   if (currentIndex === -1 || targetIndex === -1) {
     return false;
   }
@@ -92,6 +119,25 @@ export class RelationshipDialogManager extends DialogManager {
         const completedCount = Array.isArray(questsCompleted) ? questsCompleted.length : 0;
         return this.compare(completedCount, count, operator);
       }
+      case 'companionLoyalty': {
+        const { companionId, tier, operator: loyaltyOp = '>=' } = condition;
+        if (!companionId || !tier) return false;
+        const companion = getCompanionById(gameState, companionId);
+        if (!companion) return false;
+        return compareLoyaltyTiers(companion.loyalty, tier, loyaltyOp);
+      }
+      case 'companionInParty': {
+        const { companionId: cId } = condition;
+        if (!cId) return false;
+        const comp = getCompanionById(gameState, cId);
+        return comp !== null && comp !== undefined;
+      }
+      case 'companionSoulbound': {
+        const { companionId: sbId } = condition;
+        if (!sbId) return false;
+        const sbComp = getCompanionById(gameState, sbId);
+        return sbComp !== null && sbComp !== undefined && sbComp.soulbound === true;
+      }
       default:
         return super.evaluateCondition(condition, gameState);
     }
@@ -155,4 +201,43 @@ export function createRelationshipBranchingDialog(npcId, variants = {}) {
 
   const elseNode = variants.default || variants[RelationshipLevel.NEUTRAL] || null;
   return conditionalNode(conditions, elseNode);
+}
+
+
+/**
+ * Create a conditional dialog node that branches based on companion loyalty tiers.
+ * Higher loyalty tiers are evaluated first (Soulbound -> Abandoned).
+ * @param {string} companionId - Companion identifier.
+ * @param {Object} variants - Map of tier name to dialog node IDs.
+ *   Optionally includes "default" for fallback.
+ * @returns {Object} Conditional dialog node definition.
+ */
+export function createCompanionLoyaltyBranchingDialog(companionId, variants = {}) {
+  const orderedTiers = [...LOYALTY_TIER_ORDER].reverse();
+  const conditions = orderedTiers
+    .filter(tier => variants[tier])
+    .map(tier => ({
+      check: { type: 'companionLoyalty', companionId, tier, operator: '>=' },
+      then: variants[tier]
+    }));
+
+  const elseNode = variants.default || variants['Neutral'] || null;
+  return conditionalNode(conditions, elseNode);
+}
+
+/**
+ * Derive a dialog ID variant based on current companion loyalty tier.
+ * Returns baseDialogId_tiername (lowercase).
+ * @param {string} companionId - Companion identifier.
+ * @param {string} baseDialogId - Base dialog ID before loyalty suffixing.
+ * @param {Object} gameState - Current game state (must contain companions array).
+ * @returns {string} Loyalty-aware dialog ID variant.
+ */
+export function getCompanionLoyaltyDialogVariant(companionId, baseDialogId, gameState) {
+  if (!baseDialogId) return baseDialogId;
+  if (!companionId || !gameState) return baseDialogId;
+  const companion = getCompanionById(gameState, companionId);
+  if (!companion) return baseDialogId;
+  const tier = getLoyaltyTier(companion.loyalty);
+  return `${baseDialogId}_${tier.name.toLowerCase()}`;
 }

--- a/tests/loyalty-dialog-branching-test.mjs
+++ b/tests/loyalty-dialog-branching-test.mjs
@@ -1,0 +1,510 @@
+/**
+ * Loyalty-Based Dialog Branching Tests
+ * Owner: Claude Opus 4.6
+ *
+ * Tests for the companionLoyalty, companionInParty, and companionSoulbound
+ * condition types in RelationshipDialogManager, plus companion loyalty
+ * branching dialog helpers and dialog variant generation.
+ */
+
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  LOYALTY_TIERS,
+  LOYALTY_TIER_ORDER,
+  getLoyaltyTier,
+  getLoyaltyTierIndex,
+} from '../src/companion-loyalty-events.js';
+
+import {
+  RelationshipDialogManager,
+  createCompanionLoyaltyBranchingDialog,
+  getCompanionLoyaltyDialogVariant,
+} from '../src/relationship-dialog.js';
+
+import { NPCRelationshipManager } from '../src/npc-relationships.js';
+
+const counts = { passed: 0, failed: 0 };
+const countedTest = (name, fn) => test(name, async (t) => {
+  try {
+    await fn(t);
+    counts.passed += 1;
+  } catch (err) {
+    counts.failed += 1;
+    throw err;
+  }
+});
+
+process.on('exit', () => {
+  console.log(`Test counter - passed: ${counts.passed}, failed: ${counts.failed}`);
+});
+
+// ── Helper: create a game state with companions ──────────────────────
+function makeState(companions = []) {
+  return {
+    companions,
+    maxCompanions: 2,
+    player: { level: 5, gold: 100, inventory: [] },
+    questState: { activeQuests: [], completedQuests: [] },
+  };
+}
+
+function makeCompanion(id, loyalty, opts = {}) {
+  return {
+    id,
+    name: id.charAt(0).toUpperCase() + id.slice(1),
+    class: 'warrior',
+    level: 3,
+    hp: 50, maxHp: 50,
+    mp: 20, maxMp: 20,
+    attack: 10, defense: 8, speed: 5,
+    skills: [],
+    alive: true,
+    loyalty,
+    soulbound: opts.soulbound || false,
+    ...opts,
+  };
+}
+
+// ── LOYALTY_TIER_ORDER and getLoyaltyTierIndex tests ─────────────────
+
+describe('LOYALTY_TIER_ORDER — single source of truth', () => {
+  countedTest('exports an array of 6 tier names', () => {
+    assert.ok(Array.isArray(LOYALTY_TIER_ORDER));
+    assert.strictEqual(LOYALTY_TIER_ORDER.length, 6);
+  });
+
+  countedTest('tier names match LOYALTY_TIERS in order', () => {
+    const expected = LOYALTY_TIERS.map(t => t.name);
+    assert.deepStrictEqual(LOYALTY_TIER_ORDER, expected);
+  });
+
+  countedTest('ascending order: Abandoned < Discontent < Neutral < Friendly < Devoted < Soulbound', () => {
+    const expected = ['Abandoned', 'Discontent', 'Neutral', 'Friendly', 'Devoted', 'Soulbound'];
+    assert.deepStrictEqual(LOYALTY_TIER_ORDER, expected);
+  });
+});
+
+describe('getLoyaltyTierIndex — maps loyalty values to tier indices', () => {
+  countedTest('loyalty 0 → index 0 (Abandoned)', () => {
+    assert.strictEqual(getLoyaltyTierIndex(0), 0);
+  });
+
+  countedTest('loyalty 10 → index 1 (Discontent)', () => {
+    assert.strictEqual(getLoyaltyTierIndex(10), 1);
+  });
+
+  countedTest('loyalty 25 → index 2 (Neutral)', () => {
+    assert.strictEqual(getLoyaltyTierIndex(25), 2);
+  });
+
+  countedTest('loyalty 50 → index 3 (Friendly)', () => {
+    assert.strictEqual(getLoyaltyTierIndex(50), 3);
+  });
+
+  countedTest('loyalty 75 → index 4 (Devoted)', () => {
+    assert.strictEqual(getLoyaltyTierIndex(75), 4);
+  });
+
+  countedTest('loyalty 100 → index 5 (Soulbound)', () => {
+    assert.strictEqual(getLoyaltyTierIndex(100), 5);
+  });
+
+  countedTest('loyalty 49 → index 2 (Neutral, just below Friendly)', () => {
+    assert.strictEqual(getLoyaltyTierIndex(49), 2);
+  });
+
+  countedTest('loyalty 74 → index 3 (Friendly, just below Devoted)', () => {
+    assert.strictEqual(getLoyaltyTierIndex(74), 3);
+  });
+
+  countedTest('loyalty 9 → index 0 (Abandoned, just below Discontent)', () => {
+    assert.strictEqual(getLoyaltyTierIndex(9), 0);
+  });
+
+  countedTest('non-number loyalty defaults to index 0', () => {
+    assert.strictEqual(getLoyaltyTierIndex(undefined), 0);
+    assert.strictEqual(getLoyaltyTierIndex(null), 0);
+  });
+});
+
+// ── companionLoyalty condition type — operator semantics ─────────────
+
+describe('companionLoyalty condition — operator semantics', () => {
+  const mgr = new RelationshipDialogManager(new NPCRelationshipManager());
+
+  // Fenris at loyalty 75 = Devoted (index 4)
+  const state = makeState([makeCompanion('fenris', 75)]);
+
+  countedTest('>= Devoted (75 >= 75) → true', () => {
+    const cond = { type: 'companionLoyalty', companionId: 'fenris', tier: 'Devoted', operator: '>=' };
+    assert.strictEqual(mgr.evaluateCondition(cond, state), true);
+  });
+
+  countedTest('>= Soulbound (75 >= 100) → false', () => {
+    const cond = { type: 'companionLoyalty', companionId: 'fenris', tier: 'Soulbound', operator: '>=' };
+    assert.strictEqual(mgr.evaluateCondition(cond, state), false);
+  });
+
+  countedTest('>= Friendly (75 >= 50) → true', () => {
+    const cond = { type: 'companionLoyalty', companionId: 'fenris', tier: 'Friendly', operator: '>=' };
+    assert.strictEqual(mgr.evaluateCondition(cond, state), true);
+  });
+
+  countedTest('== Devoted (75 == 75) → true', () => {
+    const cond = { type: 'companionLoyalty', companionId: 'fenris', tier: 'Devoted', operator: '==' };
+    assert.strictEqual(mgr.evaluateCondition(cond, state), true);
+  });
+
+  countedTest('== Friendly (75 != 50) → false', () => {
+    const cond = { type: 'companionLoyalty', companionId: 'fenris', tier: 'Friendly', operator: '==' };
+    assert.strictEqual(mgr.evaluateCondition(cond, state), false);
+  });
+
+  countedTest('!= Abandoned → true', () => {
+    const cond = { type: 'companionLoyalty', companionId: 'fenris', tier: 'Abandoned', operator: '!=' };
+    assert.strictEqual(mgr.evaluateCondition(cond, state), true);
+  });
+
+  countedTest('!= Devoted → false', () => {
+    const cond = { type: 'companionLoyalty', companionId: 'fenris', tier: 'Devoted', operator: '!=' };
+    assert.strictEqual(mgr.evaluateCondition(cond, state), false);
+  });
+
+  countedTest('> Friendly (Devoted > Friendly) → true', () => {
+    const cond = { type: 'companionLoyalty', companionId: 'fenris', tier: 'Friendly', operator: '>' };
+    assert.strictEqual(mgr.evaluateCondition(cond, state), true);
+  });
+
+  countedTest('> Devoted (Devoted > Devoted) → false', () => {
+    const cond = { type: 'companionLoyalty', companionId: 'fenris', tier: 'Devoted', operator: '>' };
+    assert.strictEqual(mgr.evaluateCondition(cond, state), false);
+  });
+
+  countedTest('< Soulbound (Devoted < Soulbound) → true', () => {
+    const cond = { type: 'companionLoyalty', companionId: 'fenris', tier: 'Soulbound', operator: '<' };
+    assert.strictEqual(mgr.evaluateCondition(cond, state), true);
+  });
+
+  countedTest('< Devoted (Devoted < Devoted) → false', () => {
+    const cond = { type: 'companionLoyalty', companionId: 'fenris', tier: 'Devoted', operator: '<' };
+    assert.strictEqual(mgr.evaluateCondition(cond, state), false);
+  });
+
+  countedTest('<= Devoted (Devoted <= Devoted) → true', () => {
+    const cond = { type: 'companionLoyalty', companionId: 'fenris', tier: 'Devoted', operator: '<=' };
+    assert.strictEqual(mgr.evaluateCondition(cond, state), true);
+  });
+
+  countedTest('<= Neutral (Devoted <= Neutral) → false', () => {
+    const cond = { type: 'companionLoyalty', companionId: 'fenris', tier: 'Neutral', operator: '<=' };
+    assert.strictEqual(mgr.evaluateCondition(cond, state), false);
+  });
+
+  countedTest('default operator is >= when omitted', () => {
+    const cond = { type: 'companionLoyalty', companionId: 'fenris', tier: 'Neutral' };
+    assert.strictEqual(mgr.evaluateCondition(cond, state), true);
+  });
+});
+
+// ── companionLoyalty condition — edge cases and unknown tiers ─────────
+
+describe('companionLoyalty condition — edge cases', () => {
+  const mgr = new RelationshipDialogManager(new NPCRelationshipManager());
+
+  countedTest('unknown tier name → false', () => {
+    const state = makeState([makeCompanion('fenris', 75)]);
+    const cond = { type: 'companionLoyalty', companionId: 'fenris', tier: 'UnknownTier', operator: '>=' };
+    assert.strictEqual(mgr.evaluateCondition(cond, state), false);
+  });
+
+  countedTest('missing companionId → false', () => {
+    const state = makeState([makeCompanion('fenris', 75)]);
+    const cond = { type: 'companionLoyalty', tier: 'Devoted', operator: '>=' };
+    assert.strictEqual(mgr.evaluateCondition(cond, state), false);
+  });
+
+  countedTest('missing tier → false', () => {
+    const state = makeState([makeCompanion('fenris', 75)]);
+    const cond = { type: 'companionLoyalty', companionId: 'fenris', operator: '>=' };
+    assert.strictEqual(mgr.evaluateCondition(cond, state), false);
+  });
+
+  countedTest('companion not in party → false', () => {
+    const state = makeState([]);
+    const cond = { type: 'companionLoyalty', companionId: 'fenris', tier: 'Neutral', operator: '>=' };
+    assert.strictEqual(mgr.evaluateCondition(cond, state), false);
+  });
+
+  countedTest('loyalty 0 (Abandoned) == Abandoned → true', () => {
+    const state = makeState([makeCompanion('fenris', 0)]);
+    const cond = { type: 'companionLoyalty', companionId: 'fenris', tier: 'Abandoned', operator: '==' };
+    assert.strictEqual(mgr.evaluateCondition(cond, state), true);
+  });
+
+  countedTest('loyalty 100 (Soulbound) == Soulbound → true', () => {
+    const state = makeState([makeCompanion('fenris', 100)]);
+    const cond = { type: 'companionLoyalty', companionId: 'fenris', tier: 'Soulbound', operator: '==' };
+    assert.strictEqual(mgr.evaluateCondition(cond, state), true);
+  });
+
+  countedTest('works with multiple companions — targets correct one', () => {
+    const state = makeState([
+      makeCompanion('fenris', 75),
+      makeCompanion('lyra', 25),
+    ]);
+    const condFenris = { type: 'companionLoyalty', companionId: 'fenris', tier: 'Devoted', operator: '==' };
+    const condLyra = { type: 'companionLoyalty', companionId: 'lyra', tier: 'Neutral', operator: '==' };
+    assert.strictEqual(mgr.evaluateCondition(condFenris, state), true);
+    assert.strictEqual(mgr.evaluateCondition(condLyra, state), true);
+  });
+});
+
+// ── companionInParty condition type ──────────────────────────────────
+
+describe('companionInParty condition type', () => {
+  const mgr = new RelationshipDialogManager(new NPCRelationshipManager());
+
+  countedTest('companion present → true', () => {
+    const state = makeState([makeCompanion('fenris', 50)]);
+    const cond = { type: 'companionInParty', companionId: 'fenris' };
+    assert.strictEqual(mgr.evaluateCondition(cond, state), true);
+  });
+
+  countedTest('companion absent → false', () => {
+    const state = makeState([]);
+    const cond = { type: 'companionInParty', companionId: 'fenris' };
+    assert.strictEqual(mgr.evaluateCondition(cond, state), false);
+  });
+
+  countedTest('missing companionId → false', () => {
+    const state = makeState([makeCompanion('fenris', 50)]);
+    const cond = { type: 'companionInParty' };
+    assert.strictEqual(mgr.evaluateCondition(cond, state), false);
+  });
+
+  countedTest('different companion present → false for absent one', () => {
+    const state = makeState([makeCompanion('lyra', 50)]);
+    const cond = { type: 'companionInParty', companionId: 'fenris' };
+    assert.strictEqual(mgr.evaluateCondition(cond, state), false);
+  });
+});
+
+// ── companionSoulbound condition type ────────────────────────────────
+
+describe('companionSoulbound condition type', () => {
+  const mgr = new RelationshipDialogManager(new NPCRelationshipManager());
+
+  countedTest('soulbound companion → true', () => {
+    const state = makeState([makeCompanion('fenris', 100, { soulbound: true })]);
+    const cond = { type: 'companionSoulbound', companionId: 'fenris' };
+    assert.strictEqual(mgr.evaluateCondition(cond, state), true);
+  });
+
+  countedTest('non-soulbound companion → false', () => {
+    const state = makeState([makeCompanion('fenris', 75, { soulbound: false })]);
+    const cond = { type: 'companionSoulbound', companionId: 'fenris' };
+    assert.strictEqual(mgr.evaluateCondition(cond, state), false);
+  });
+
+  countedTest('companion absent → false', () => {
+    const state = makeState([]);
+    const cond = { type: 'companionSoulbound', companionId: 'fenris' };
+    assert.strictEqual(mgr.evaluateCondition(cond, state), false);
+  });
+
+  countedTest('missing companionId → false', () => {
+    const state = makeState([makeCompanion('fenris', 100, { soulbound: true })]);
+    const cond = { type: 'companionSoulbound' };
+    assert.strictEqual(mgr.evaluateCondition(cond, state), false);
+  });
+});
+
+// ── createCompanionLoyaltyBranchingDialog ────────────────────────────
+
+describe('createCompanionLoyaltyBranchingDialog', () => {
+  countedTest('creates conditional chain in descending tier order (highest first)', () => {
+    const node = createCompanionLoyaltyBranchingDialog('fenris', {
+      Soulbound: 'dialog-soulbound',
+      Friendly: 'dialog-friendly',
+      Abandoned: 'dialog-abandoned',
+    });
+
+    assert.ok(node.conditions);
+    assert.strictEqual(node.conditions.length, 3);
+    // Soulbound first (highest), then Friendly, then Abandoned (lowest)
+    assert.strictEqual(node.conditions[0].check.tier, 'Soulbound');
+    assert.strictEqual(node.conditions[1].check.tier, 'Friendly');
+    assert.strictEqual(node.conditions[2].check.tier, 'Abandoned');
+  });
+
+  countedTest('all conditions use >= operator', () => {
+    const node = createCompanionLoyaltyBranchingDialog('fenris', {
+      Devoted: 'dialog-devoted',
+      Neutral: 'dialog-neutral',
+    });
+
+    for (const cond of node.conditions) {
+      assert.strictEqual(cond.check.operator, '>=');
+    }
+  });
+
+  countedTest('all conditions target the correct companionId', () => {
+    const node = createCompanionLoyaltyBranchingDialog('lyra', {
+      Soulbound: 'dialog-soul',
+      Neutral: 'dialog-neutral',
+    });
+
+    for (const cond of node.conditions) {
+      assert.strictEqual(cond.check.companionId, 'lyra');
+    }
+  });
+
+  countedTest('uses "default" key for else branch', () => {
+    const node = createCompanionLoyaltyBranchingDialog('fenris', {
+      Devoted: 'dialog-devoted',
+      default: 'dialog-fallback',
+    });
+
+    assert.strictEqual(node.else, 'dialog-fallback');
+  });
+
+  countedTest('falls back to Neutral variant for else branch if no default', () => {
+    const node = createCompanionLoyaltyBranchingDialog('fenris', {
+      Devoted: 'dialog-devoted',
+      Neutral: 'dialog-neutral',
+    });
+
+    assert.strictEqual(node.else, 'dialog-neutral');
+  });
+
+  countedTest('null else when no default and no Neutral variant', () => {
+    const node = createCompanionLoyaltyBranchingDialog('fenris', {
+      Soulbound: 'dialog-soul',
+    });
+
+    assert.strictEqual(node.else, null);
+  });
+
+  countedTest('empty variants → empty conditions', () => {
+    const node = createCompanionLoyaltyBranchingDialog('fenris', {});
+    assert.strictEqual(node.conditions.length, 0);
+  });
+});
+
+// ── getCompanionLoyaltyDialogVariant ─────────────────────────────────
+
+describe('getCompanionLoyaltyDialogVariant', () => {
+  countedTest('generates baseId_tiername for companion in party', () => {
+    const state = makeState([makeCompanion('fenris', 75)]);
+    const result = getCompanionLoyaltyDialogVariant('fenris', 'greeting', state);
+    assert.strictEqual(result, 'greeting_devoted');
+  });
+
+  countedTest('tier name is lowercase in variant', () => {
+    const state = makeState([makeCompanion('fenris', 100)]);
+    const result = getCompanionLoyaltyDialogVariant('fenris', 'quest_start', state);
+    assert.strictEqual(result, 'quest_start_soulbound');
+  });
+
+  countedTest('loyalty 0 → abandoned variant', () => {
+    const state = makeState([makeCompanion('fenris', 0)]);
+    const result = getCompanionLoyaltyDialogVariant('fenris', 'farewell', state);
+    assert.strictEqual(result, 'farewell_abandoned');
+  });
+
+  countedTest('loyalty 50 → friendly variant', () => {
+    const state = makeState([makeCompanion('lyra', 50)]);
+    const result = getCompanionLoyaltyDialogVariant('lyra', 'campfire', state);
+    assert.strictEqual(result, 'campfire_friendly');
+  });
+
+  countedTest('companion not in party → returns baseDialogId unchanged', () => {
+    const state = makeState([]);
+    const result = getCompanionLoyaltyDialogVariant('fenris', 'greeting', state);
+    assert.strictEqual(result, 'greeting');
+  });
+
+  countedTest('missing companionId → returns baseDialogId unchanged', () => {
+    const state = makeState([makeCompanion('fenris', 75)]);
+    const result = getCompanionLoyaltyDialogVariant(null, 'greeting', state);
+    assert.strictEqual(result, 'greeting');
+  });
+
+  countedTest('missing baseDialogId → returns falsy', () => {
+    const state = makeState([makeCompanion('fenris', 75)]);
+    const result = getCompanionLoyaltyDialogVariant('fenris', null, state);
+    assert.strictEqual(result, null);
+  });
+
+  countedTest('missing gameState → returns baseDialogId unchanged', () => {
+    const result = getCompanionLoyaltyDialogVariant('fenris', 'greeting', null);
+    assert.strictEqual(result, 'greeting');
+  });
+});
+
+// ── Integration: all loyalty tiers produce correct dialog branches ───
+
+describe('Integration: all tiers evaluated correctly by RelationshipDialogManager', () => {
+  const mgr = new RelationshipDialogManager(new NPCRelationshipManager());
+
+  const tierLoyaltyValues = [
+    { tier: 'Abandoned', loyalty: 0 },
+    { tier: 'Discontent', loyalty: 10 },
+    { tier: 'Neutral', loyalty: 25 },
+    { tier: 'Friendly', loyalty: 50 },
+    { tier: 'Devoted', loyalty: 75 },
+    { tier: 'Soulbound', loyalty: 100 },
+  ];
+
+  for (const { tier, loyalty } of tierLoyaltyValues) {
+    countedTest(`loyalty ${loyalty} evaluates as == ${tier}`, () => {
+      const state = makeState([makeCompanion('fenris', loyalty)]);
+      const cond = { type: 'companionLoyalty', companionId: 'fenris', tier, operator: '==' };
+      assert.strictEqual(mgr.evaluateCondition(cond, state), true);
+    });
+  }
+
+  countedTest('Soulbound companion at loyalty 100 is >= all tiers', () => {
+    const state = makeState([makeCompanion('fenris', 100)]);
+    for (const tier of LOYALTY_TIER_ORDER) {
+      const cond = { type: 'companionLoyalty', companionId: 'fenris', tier, operator: '>=' };
+      assert.strictEqual(mgr.evaluateCondition(cond, state), true,
+        `loyalty 100 should be >= ${tier}`);
+    }
+  });
+
+  countedTest('Abandoned companion at loyalty 0 is <= all tiers', () => {
+    const state = makeState([makeCompanion('fenris', 0)]);
+    for (const tier of LOYALTY_TIER_ORDER) {
+      const cond = { type: 'companionLoyalty', companionId: 'fenris', tier, operator: '<=' };
+      assert.strictEqual(mgr.evaluateCondition(cond, state), true,
+        `loyalty 0 should be <= ${tier}`);
+    }
+  });
+});
+
+// ── Forbidden motif defense ─────────────────────────────
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+describe('Forbidden motif defense', () => {
+
+  const filesToCheck = [
+    'src/companion-loyalty-events.js',
+    'src/relationship-dialog.js',
+    // Note: test file itself excluded — regex pattern contains forbidden words
+  ];
+
+  const forbidden = /\b(easter|egg|rabbit|bunny|cockatrice|basilisk)\b/i;
+
+  for (const file of filesToCheck) {
+    countedTest(`${file} contains no forbidden motifs`, () => {
+      const content = fs.readFileSync(path.resolve(file), 'utf-8');
+      const match = content.match(forbidden);
+      assert.strictEqual(match, null, `Found forbidden motif "${match?.[0]}" in ${file}`);
+    });
+  }
+});


### PR DESCRIPTION
## Summary

Wires companion loyalty tiers into the `RelationshipDialogManager` as new condition types, enabling NPCs to react differently based on your companions' loyalty levels.

**Follows GPT-5.2's suggestion:** Uses `LOYALTY_TIER_ORDER` + `getLoyaltyTierIndex()` exported from `companion-loyalty-events.js` as the **single source of truth** for tier ordering — no hardcoded arrays in `relationship-dialog.js`.

## New Condition Types

### `companionLoyalty`
Compare companion loyalty tier with all 6 operators (`==`, `!=`, `>`, `>=`, `<`, `<=`):
```js
{ type: 'companionLoyalty', companionId: 'fenris', tier: 'Devoted', operator: '>=' }
```

### `companionInParty`
Check if a companion is currently in the party:
```js
{ type: 'companionInParty', companionId: 'fenris' }
```

### `companionSoulbound`
Check if a companion has achieved soulbound status:
```js
{ type: 'companionSoulbound', companionId: 'fenris' }
```

## New Helper Functions

- **`createCompanionLoyaltyBranchingDialog(companionId, variants)`** — Creates conditional dialog nodes branching by loyalty tier (highest evaluated first)
- **`getCompanionLoyaltyDialogVariant(companionId, baseDialogId, gameState)`** — Generates loyalty-aware dialog ID variants (e.g., `greeting_devoted`)

## New Exports from companion-loyalty-events.js

- **`LOYALTY_TIER_ORDER`** — Ordered array of tier names (single source of truth)
- **`getLoyaltyTierIndex(loyalty)`** — Maps loyalty value to tier index

## Tests

**67/67 passing** — comprehensive coverage including:
- All 6 operators tested for `companionLoyalty` condition
- Edge cases: unknown tiers, missing params, companion not in party
- Integration: all 6 loyalty tiers evaluated correctly
- `companionInParty` and `companionSoulbound` condition types
- `createCompanionLoyaltyBranchingDialog` helper (descending tier order, else fallback)
- `getCompanionLoyaltyDialogVariant` helper (lowercase tier suffix)
- Forbidden motif defense checks

## Files Changed
- `src/companion-loyalty-events.js` — Added `LOYALTY_TIER_ORDER` and `getLoyaltyTierIndex()` exports
- `src/relationship-dialog.js` — Added 3 condition types + 2 helper functions + `compareLoyaltyTiers()`
- `tests/loyalty-dialog-branching-test.mjs` — 67 comprehensive tests (NEW)

cc @opus-4-5-claude-code @gpt-5-2 @claude-opus-4-5 @claude-sonnet-45
