### PR TITLE
feat: quest companion requirements + getLoyaltyTierIndex defensive fallback

### DIFF
--- a/src/companion-loyalty-events.js
+++ b/src/companion-loyalty-events.js
@@ -31,7 +31,8 @@ export const LOYALTY_TIER_ORDER = LOYALTY_TIERS.map(t => t.name);
  */
 export function getLoyaltyTierIndex(loyalty) {
   const tier = getLoyaltyTier(loyalty);
-  return LOYALTY_TIER_ORDER.indexOf(tier.name);
+  const idx = LOYALTY_TIER_ORDER.indexOf(tier.name);
+  return idx !== -1 ? idx : 0;
 }
 
 /**

--- a/src/quest-integration.js
+++ b/src/quest-integration.js
@@ -5,6 +5,8 @@
  */
 
 import { getExplorationQuest, getExplorationQuests, getQuestsForRoom } from './data/exploration-quests.js';
+import { getCompanionById, isCompanionRecruited } from './companions.js';
+import { getLoyaltyTier, getLoyaltyTierIndex, LOYALTY_TIER_ORDER } from './companion-loyalty-events.js';
 
 /**
  * Initialize quest tracking state
@@ -20,12 +22,59 @@ function initQuestState() {
 }
 
 /**
+ * Check if companion requirements for a quest are met.
+ * Quest definitions may include a companionRequirements array:
+ *   [{ companionId, inParty?, minLoyaltyTier?, requireSoulbound? }]
+ * Each entry specifies constraints for ONE companion.
+ * @param {Object} gameState - Full game state (must have companions array)
+ * @param {Array} requirements - Array of companion requirement objects
+ * @returns {{ met: boolean, unmet: Array<{companionId: string, reason: string}> }}
+ */
+function checkCompanionRequirements(gameState, requirements) {
+  if (!requirements || !Array.isArray(requirements) || requirements.length === 0) {
+    return { met: true, unmet: [] };
+  }
+
+  const unmet = [];
+
+  for (const req of requirements) {
+    if (!req.companionId) continue;
+
+    // Check if companion is in party
+    const companion = getCompanionById(gameState, req.companionId);
+
+    if (req.inParty) {
+      if (!companion) {
+        unmet.push({ companionId: req.companionId, reason: 'not_in_party' });
+        continue; // Can't check loyalty/soulbound if not in party
+      }
+    }
+
+    if (req.minLoyaltyTier && companion) {
+      const requiredIndex = LOYALTY_TIER_ORDER.indexOf(req.minLoyaltyTier);
+      const currentIndex = getLoyaltyTierIndex(companion.loyalty ?? 0);
+      if (requiredIndex === -1 || currentIndex < requiredIndex) {
+        unmet.push({ companionId: req.companionId, reason: 'loyalty_too_low' });
+      }
+    }
+
+    if (req.requireSoulbound) {
+      if (!companion || !companion.soulbound) {
+        unmet.push({ companionId: req.companionId, reason: 'not_soulbound' });
+      }
+    }
+  }
+
+  return { met: unmet.length === 0, unmet };
+}
+
+/**
  * Accept a quest, adding it to active quests
  * @param {Object} questState - Current quest state
  * @param {string} questId - Quest to accept
  * @returns {Object} { questState, accepted, message }
  */
-function acceptQuest(questState, questId) {
+function acceptQuest(questState, questId, gameState) {
   const quest = getExplorationQuest(questId);
   if (!quest) {
     return { questState, accepted: false, message: `Quest "${questId}" not found.` };
@@ -43,6 +92,20 @@ function acceptQuest(questState, questId) {
   for (const prereq of quest.prerequisites || []) {
     if (!questState.completedQuests.includes(prereq)) {
       return { questState, accepted: false, message: `Must complete prerequisite quest first.` };
+    }
+  }
+
+  // Check companion requirements (if gameState provided)
+  if (gameState && quest.companionRequirements) {
+    const { met, unmet } = checkCompanionRequirements(gameState, quest.companionRequirements);
+    if (!met) {
+      const reasons = unmet.map(u => {
+        if (u.reason === 'not_in_party') return u.companionId + ' must be in your party';
+        if (u.reason === 'loyalty_too_low') return u.companionId + ' loyalty is too low';
+        if (u.reason === 'not_soulbound') return u.companionId + ' must be soulbound';
+        return u.companionId + ': requirement not met';
+      });
+      return { questState, accepted: false, message: 'Companion requirements not met: ' + reasons.join('; ') + '.' };
     }
   }
 
@@ -336,7 +399,7 @@ function getQuestProgress(questState, questId) {
  * @param {string} roomId - Room ID
  * @returns {Array} Array of quest objects available to accept
  */
-function getAvailableQuestsInRoom(questState, roomId) {
+function getAvailableQuestsInRoom(questState, roomId, gameState) {
   const roomQuests = getQuestsForRoom(roomId);
   return roomQuests.filter(quest => {
     // Not already active or completed
@@ -345,6 +408,11 @@ function getAvailableQuestsInRoom(questState, roomId) {
     // Prerequisites met
     for (const prereq of quest.prerequisites || []) {
       if (!questState.completedQuests.includes(prereq)) return false;
+    }
+    // Check companion requirements (if gameState provided)
+    if (gameState && quest.companionRequirements) {
+      const { met } = checkCompanionRequirements(gameState, quest.companionRequirements);
+      if (!met) return false;
     }
     return true;
   });
@@ -357,6 +425,167 @@ function getAvailableQuestsInRoom(questState, roomId) {
  */
 function getActiveQuestsSummary(questState) {
   return questState.activeQuests.map(questId => getQuestProgress(questState, questId)).filter(Boolean);
+}
+
+/**
+ * Check if companion-related stage objectives are satisfied.
+ * Supports objective types: COMPANION_IN_PARTY, COMPANION_LOYALTY, COMPANION_SOULBOUND
+ * @param {Object} gameState - Full game state
+ * @param {Object} objective - Objective definition
+ * @returns {boolean} Whether the objective is currently satisfied
+ */
+function checkCompanionObjective(gameState, objective) {
+  if (!gameState || !objective) return false;
+
+  const companion = getCompanionById(gameState, objective.companionId);
+
+  switch (objective.type) {
+    case 'COMPANION_IN_PARTY':
+      return !!companion;
+    case 'COMPANION_LOYALTY': {
+      if (!companion) return false;
+      const requiredIndex = LOYALTY_TIER_ORDER.indexOf(objective.minLoyaltyTier);
+      const currentIndex = getLoyaltyTierIndex(companion.loyalty ?? 0);
+      return requiredIndex !== -1 && currentIndex >= requiredIndex;
+    }
+    case 'COMPANION_SOULBOUND':
+      return !!companion && !!companion.soulbound;
+    default:
+      return false;
+  }
+}
+
+/**
+ * Check all companion-type objectives in the current stage of active quests.
+ * Call this whenever party composition or loyalty changes.
+ * @param {Object} questState - Current quest state
+ * @param {Object} gameState - Full game state (with companions)
+ * @returns {Object} { questState, messages, completedObjectives, completedStages, completedQuests }
+ */
+function onCompanionStateChange(questState, gameState) {
+  const messages = [];
+  const completedObjectives = [];
+  const completedStages = [];
+  const completedQuests = [];
+  let newState = questState;
+
+  for (const questId of newState.activeQuests) {
+    const quest = getExplorationQuest(questId);
+    if (!quest) continue;
+
+    const progress = newState.questProgress[questId];
+    if (!progress) continue;
+
+    const stage = quest.stages[progress.stageIndex];
+    if (!stage || !stage.objectives) continue;
+
+    let stageComplete = true;
+    let objectiveUpdated = false;
+
+    for (const objective of stage.objectives) {
+      const isCompanionType = ['COMPANION_IN_PARTY', 'COMPANION_LOYALTY', 'COMPANION_SOULBOUND'].includes(objective.type);
+
+      if (isCompanionType) {
+        const satisfied = checkCompanionObjective(gameState, objective);
+        const wasSatisfied = progress.objectiveProgress[objective.id] === true;
+
+        if (satisfied && !wasSatisfied) {
+          newState = {
+            ...newState,
+            questProgress: {
+              ...newState.questProgress,
+              [questId]: {
+                ...newState.questProgress[questId],
+                objectiveProgress: {
+                  ...newState.questProgress[questId].objectiveProgress,
+                  [objective.id]: true
+                }
+              }
+            }
+          };
+          objectiveUpdated = true;
+          completedObjectives.push({ questId, objectiveId: objective.id, description: objective.description });
+          messages.push(`✓ ${objective.description}`);
+        }
+
+        // For required companion objectives, re-evaluate satisfaction live
+        if (objective.required && !satisfied) {
+          stageComplete = false;
+        }
+      } else {
+        // Non-companion objectives: check existing progress
+        const objProgress = newState.questProgress[questId].objectiveProgress[objective.id];
+        if (objective.required) {
+          if (objective.type === 'KILL') {
+            if ((objProgress || 0) < objective.count) stageComplete = false;
+          } else if (!objProgress) {
+            stageComplete = false;
+          }
+        }
+      }
+    }
+
+    // Handle stage/quest completion
+    if (stageComplete && objectiveUpdated) {
+      const nextStageId = stage.nextStage;
+      if (nextStageId) {
+        const nextStageIndex = quest.stages.findIndex(s => s.id === nextStageId);
+        if (nextStageIndex !== -1) {
+          newState = {
+            ...newState,
+            questProgress: {
+              ...newState.questProgress,
+              [questId]: {
+                ...newState.questProgress[questId],
+                stageIndex: nextStageIndex,
+                objectiveProgress: {}
+              }
+            }
+          };
+          completedStages.push({ questId, stageId: stage.id, stageName: stage.name });
+          messages.push(`Stage complete: ${stage.name}`);
+          messages.push(`New objective: ${quest.stages[nextStageIndex].name}`);
+        }
+      } else {
+        newState = {
+          ...newState,
+          activeQuests: newState.activeQuests.filter(id => id !== questId),
+          completedQuests: [...newState.completedQuests, questId],
+          questProgress: {
+            ...newState.questProgress,
+            [questId]: { ...newState.questProgress[questId], completed: true }
+          }
+        };
+        completedQuests.push({ questId, questName: quest.name, rewards: quest.rewards });
+        messages.push(`★ Quest complete: ${quest.name}!`);
+        if (quest.rewards) {
+          if (quest.rewards.experience) messages.push(`  +${quest.rewards.experience} XP`);
+          if (quest.rewards.gold) messages.push(`  +${quest.rewards.gold} Gold`);
+          if (quest.rewards.items && quest.rewards.items.length) messages.push(`  Items: ${quest.rewards.items.join(', ')}`);
+        }
+      }
+    }
+  }
+
+  return { questState: newState, messages, completedObjectives, completedStages, completedQuests };
+}
+
+/**
+ * Get a human-readable description of companion requirements for a quest
+ * @param {Object} quest - Quest definition object
+ * @returns {Array<string>} Array of requirement description strings
+ */
+function describeCompanionRequirements(quest) {
+  if (!quest || !quest.companionRequirements || !Array.isArray(quest.companionRequirements)) {
+    return [];
+  }
+  return quest.companionRequirements.map(req => {
+    const parts = [];
+    if (req.inParty) parts.push(req.companionId + ' must be in party');
+    if (req.minLoyaltyTier) parts.push(req.companionId + ' loyalty: ' + req.minLoyaltyTier + '+');
+    if (req.requireSoulbound) parts.push(req.companionId + ' must be soulbound');
+    return parts.join(', ');
+  }).filter(s => s.length > 0);
 }
 
 /**
@@ -403,5 +632,9 @@ export {
   getQuestProgress,
   getAvailableQuestsInRoom,
   getActiveQuestsSummary,
-  applyQuestRewards
+  applyQuestRewards,
+  checkCompanionRequirements,
+  checkCompanionObjective,
+  onCompanionStateChange,
+  describeCompanionRequirements
 };

--- a/tests/quest-companion-requirements-test.mjs
+++ b/tests/quest-companion-requirements-test.mjs
@@ -1,0 +1,600 @@
+/**
+ * Quest Companion Requirements Tests — AI Village RPG
+ * Owner: Claude Opus 4.6
+ *
+ * Tests for quest-level companion gates and stage-level companion objectives.
+ * Covers: checkCompanionRequirements, acceptQuest with gameState,
+ *         checkCompanionObjective, onCompanionStateChange,
+ *         getAvailableQuestsInRoom, describeCompanionRequirements,
+ *         and the getLoyaltyTierIndex defensive fallback.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  checkCompanionRequirements,
+  checkCompanionObjective,
+  onCompanionStateChange,
+  describeCompanionRequirements,
+  initQuestState,
+  acceptQuest,
+  getAvailableQuestsInRoom
+} from '../src/quest-integration.js';
+
+import {
+  getLoyaltyTierIndex,
+  LOYALTY_TIER_ORDER,
+  LOYALTY_TIERS
+} from '../src/companion-loyalty-events.js';
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function makeGameState(companions = []) {
+  return { companions };
+}
+
+function makeCompanion(id, overrides = {}) {
+  return {
+    id,
+    name: id.charAt(0).toUpperCase() + id.slice(1),
+    class: 'Adventurer',
+    level: 1,
+    hp: 50, maxHp: 50,
+    mp: 20, maxMp: 20,
+    attack: 10, defense: 5, speed: 5,
+    skills: [],
+    alive: true,
+    loyalty: 50,
+    ...overrides
+  };
+}
+
+function makeQuestState(overrides = {}) {
+  return { ...initQuestState(), ...overrides };
+}
+
+// ── getLoyaltyTierIndex defensive fallback (GPT-5.2 nit) ───────────────
+
+test('getLoyaltyTierIndex — returns 0 for loyalty 0 (Abandoned tier)', () => {
+  assert.equal(getLoyaltyTierIndex(0), 0);
+});
+
+test('getLoyaltyTierIndex — returns correct index for each tier threshold', () => {
+  for (let i = 0; i < LOYALTY_TIERS.length; i++) {
+    const tier = LOYALTY_TIERS[i];
+    assert.equal(getLoyaltyTierIndex(tier.threshold), i,
+      `Expected tier index ${i} for loyalty ${tier.threshold} (${tier.name})`);
+  }
+});
+
+test('getLoyaltyTierIndex — returns 5 for loyalty 100 (Soulbound)', () => {
+  assert.equal(getLoyaltyTierIndex(100), 5);
+});
+
+test('getLoyaltyTierIndex — returns 3 for loyalty 50 (Friendly)', () => {
+  assert.equal(getLoyaltyTierIndex(50), 3);
+});
+
+test('getLoyaltyTierIndex — handles undefined gracefully (defensive)', () => {
+  // getLoyaltyTier handles non-number by defaulting to 0
+  const idx = getLoyaltyTierIndex(undefined);
+  assert.equal(idx, 0);
+});
+
+test('getLoyaltyTierIndex — handles negative values gracefully', () => {
+  const idx = getLoyaltyTierIndex(-10);
+  assert.equal(idx, 0);
+});
+
+test('getLoyaltyTierIndex — handles NaN gracefully', () => {
+  const idx = getLoyaltyTierIndex(NaN);
+  assert.equal(idx, 0);
+});
+
+test('getLoyaltyTierIndex — mid-tier values return correct tier', () => {
+  // loyalty 60 should be Friendly (threshold 50, index 3)
+  assert.equal(getLoyaltyTierIndex(60), 3);
+  // loyalty 80 should be Devoted (threshold 75, index 4)
+  assert.equal(getLoyaltyTierIndex(80), 4);
+  // loyalty 15 should be Discontent (threshold 10, index 1)
+  assert.equal(getLoyaltyTierIndex(15), 1);
+});
+
+// ── checkCompanionRequirements ─────────────────────────────────────────
+
+test('checkCompanionRequirements — returns met:true for null/undefined/empty requirements', () => {
+  const gs = makeGameState();
+  assert.deepEqual(checkCompanionRequirements(gs, null), { met: true, unmet: [] });
+  assert.deepEqual(checkCompanionRequirements(gs, undefined), { met: true, unmet: [] });
+  assert.deepEqual(checkCompanionRequirements(gs, []), { met: true, unmet: [] });
+});
+
+test('checkCompanionRequirements — returns met:true for non-array requirements', () => {
+  const gs = makeGameState();
+  assert.deepEqual(checkCompanionRequirements(gs, 'not-an-array'), { met: true, unmet: [] });
+});
+
+test('checkCompanionRequirements — skips entries without companionId', () => {
+  const gs = makeGameState();
+  const result = checkCompanionRequirements(gs, [{ inParty: true }]);
+  assert.deepEqual(result, { met: true, unmet: [] });
+});
+
+test('checkCompanionRequirements — inParty: passes when companion is in party', () => {
+  const gs = makeGameState([makeCompanion('lyra')]);
+  const result = checkCompanionRequirements(gs, [
+    { companionId: 'lyra', inParty: true }
+  ]);
+  assert.equal(result.met, true);
+  assert.equal(result.unmet.length, 0);
+});
+
+test('checkCompanionRequirements — inParty: fails when companion not in party', () => {
+  const gs = makeGameState([]);
+  const result = checkCompanionRequirements(gs, [
+    { companionId: 'lyra', inParty: true }
+  ]);
+  assert.equal(result.met, false);
+  assert.equal(result.unmet.length, 1);
+  assert.equal(result.unmet[0].companionId, 'lyra');
+  assert.equal(result.unmet[0].reason, 'not_in_party');
+});
+
+test('checkCompanionRequirements — minLoyaltyTier: passes at exact tier', () => {
+  const gs = makeGameState([makeCompanion('lyra', { loyalty: 50 })]);
+  const result = checkCompanionRequirements(gs, [
+    { companionId: 'lyra', minLoyaltyTier: 'Friendly' }
+  ]);
+  assert.equal(result.met, true);
+});
+
+test('checkCompanionRequirements — minLoyaltyTier: passes above tier', () => {
+  const gs = makeGameState([makeCompanion('lyra', { loyalty: 80 })]);
+  const result = checkCompanionRequirements(gs, [
+    { companionId: 'lyra', minLoyaltyTier: 'Friendly' }
+  ]);
+  assert.equal(result.met, true);
+});
+
+test('checkCompanionRequirements — minLoyaltyTier: fails below tier', () => {
+  const gs = makeGameState([makeCompanion('lyra', { loyalty: 30 })]);
+  const result = checkCompanionRequirements(gs, [
+    { companionId: 'lyra', minLoyaltyTier: 'Friendly' }
+  ]);
+  assert.equal(result.met, false);
+  assert.equal(result.unmet[0].reason, 'loyalty_too_low');
+});
+
+test('checkCompanionRequirements — minLoyaltyTier: fails with invalid tier name', () => {
+  const gs = makeGameState([makeCompanion('lyra', { loyalty: 100 })]);
+  const result = checkCompanionRequirements(gs, [
+    { companionId: 'lyra', minLoyaltyTier: 'InvalidTier' }
+  ]);
+  assert.equal(result.met, false);
+  assert.equal(result.unmet[0].reason, 'loyalty_too_low');
+});
+
+test('checkCompanionRequirements — minLoyaltyTier: skipped when companion not in party (no inParty flag)', () => {
+  // If companion not in party but inParty not required, loyalty check uses companion lookup
+  // getCompanionById returns null, so companion is falsy, loyalty check skipped
+  const gs = makeGameState([]);
+  const result = checkCompanionRequirements(gs, [
+    { companionId: 'lyra', minLoyaltyTier: 'Friendly' }
+  ]);
+  // companion is null, so the `req.minLoyaltyTier && companion` check is false
+  assert.equal(result.met, true);
+});
+
+test('checkCompanionRequirements — requireSoulbound: passes when soulbound', () => {
+  const gs = makeGameState([makeCompanion('lyra', { soulbound: true })]);
+  const result = checkCompanionRequirements(gs, [
+    { companionId: 'lyra', requireSoulbound: true }
+  ]);
+  assert.equal(result.met, true);
+});
+
+test('checkCompanionRequirements — requireSoulbound: fails when not soulbound', () => {
+  const gs = makeGameState([makeCompanion('lyra', { soulbound: false })]);
+  const result = checkCompanionRequirements(gs, [
+    { companionId: 'lyra', requireSoulbound: true }
+  ]);
+  assert.equal(result.met, false);
+  assert.equal(result.unmet[0].reason, 'not_soulbound');
+});
+
+test('checkCompanionRequirements — requireSoulbound: fails when companion not in party', () => {
+  const gs = makeGameState([]);
+  const result = checkCompanionRequirements(gs, [
+    { companionId: 'lyra', requireSoulbound: true }
+  ]);
+  assert.equal(result.met, false);
+  assert.equal(result.unmet[0].reason, 'not_soulbound');
+});
+
+test('checkCompanionRequirements — combined: inParty + minLoyaltyTier + soulbound all pass', () => {
+  const gs = makeGameState([makeCompanion('lyra', { loyalty: 100, soulbound: true })]);
+  const result = checkCompanionRequirements(gs, [
+    { companionId: 'lyra', inParty: true, minLoyaltyTier: 'Soulbound', requireSoulbound: true }
+  ]);
+  assert.equal(result.met, true);
+});
+
+test('checkCompanionRequirements — combined: inParty passes but loyalty fails', () => {
+  const gs = makeGameState([makeCompanion('lyra', { loyalty: 30 })]);
+  const result = checkCompanionRequirements(gs, [
+    { companionId: 'lyra', inParty: true, minLoyaltyTier: 'Devoted' }
+  ]);
+  assert.equal(result.met, false);
+  assert.equal(result.unmet.length, 1);
+  assert.equal(result.unmet[0].reason, 'loyalty_too_low');
+});
+
+test('checkCompanionRequirements — inParty fails skips loyalty/soulbound checks', () => {
+  const gs = makeGameState([]);
+  const result = checkCompanionRequirements(gs, [
+    { companionId: 'lyra', inParty: true, minLoyaltyTier: 'Devoted', requireSoulbound: true }
+  ]);
+  // Only not_in_party should appear since continue skips remaining checks
+  assert.equal(result.met, false);
+  assert.equal(result.unmet.length, 1);
+  assert.equal(result.unmet[0].reason, 'not_in_party');
+});
+
+test('checkCompanionRequirements — multiple companions: all pass', () => {
+  const gs = makeGameState([
+    makeCompanion('lyra', { loyalty: 75 }),
+    makeCompanion('thorin', { loyalty: 50, soulbound: true })
+  ]);
+  const result = checkCompanionRequirements(gs, [
+    { companionId: 'lyra', inParty: true, minLoyaltyTier: 'Devoted' },
+    { companionId: 'thorin', inParty: true, requireSoulbound: true }
+  ]);
+  assert.equal(result.met, true);
+});
+
+test('checkCompanionRequirements — multiple companions: one fails', () => {
+  const gs = makeGameState([
+    makeCompanion('lyra', { loyalty: 75 })
+  ]);
+  const result = checkCompanionRequirements(gs, [
+    { companionId: 'lyra', inParty: true },
+    { companionId: 'thorin', inParty: true }
+  ]);
+  assert.equal(result.met, false);
+  assert.equal(result.unmet.length, 1);
+  assert.equal(result.unmet[0].companionId, 'thorin');
+});
+
+// ── checkCompanionObjective ────────────────────────────────────────────
+
+test('checkCompanionObjective — returns false for null gameState', () => {
+  assert.equal(checkCompanionObjective(null, { type: 'COMPANION_IN_PARTY', companionId: 'lyra' }), false);
+});
+
+test('checkCompanionObjective — returns false for null objective', () => {
+  assert.equal(checkCompanionObjective(makeGameState(), null), false);
+});
+
+test('checkCompanionObjective — COMPANION_IN_PARTY: true when in party', () => {
+  const gs = makeGameState([makeCompanion('lyra')]);
+  assert.equal(checkCompanionObjective(gs, { type: 'COMPANION_IN_PARTY', companionId: 'lyra' }), true);
+});
+
+test('checkCompanionObjective — COMPANION_IN_PARTY: false when not in party', () => {
+  const gs = makeGameState([]);
+  assert.equal(checkCompanionObjective(gs, { type: 'COMPANION_IN_PARTY', companionId: 'lyra' }), false);
+});
+
+test('checkCompanionObjective — COMPANION_LOYALTY: true at required tier', () => {
+  const gs = makeGameState([makeCompanion('lyra', { loyalty: 75 })]);
+  assert.equal(checkCompanionObjective(gs, {
+    type: 'COMPANION_LOYALTY', companionId: 'lyra', minLoyaltyTier: 'Devoted'
+  }), true);
+});
+
+test('checkCompanionObjective — COMPANION_LOYALTY: true above required tier', () => {
+  const gs = makeGameState([makeCompanion('lyra', { loyalty: 100 })]);
+  assert.equal(checkCompanionObjective(gs, {
+    type: 'COMPANION_LOYALTY', companionId: 'lyra', minLoyaltyTier: 'Devoted'
+  }), true);
+});
+
+test('checkCompanionObjective — COMPANION_LOYALTY: false below required tier', () => {
+  const gs = makeGameState([makeCompanion('lyra', { loyalty: 30 })]);
+  assert.equal(checkCompanionObjective(gs, {
+    type: 'COMPANION_LOYALTY', companionId: 'lyra', minLoyaltyTier: 'Devoted'
+  }), false);
+});
+
+test('checkCompanionObjective — COMPANION_LOYALTY: false when companion not in party', () => {
+  const gs = makeGameState([]);
+  assert.equal(checkCompanionObjective(gs, {
+    type: 'COMPANION_LOYALTY', companionId: 'lyra', minLoyaltyTier: 'Neutral'
+  }), false);
+});
+
+test('checkCompanionObjective — COMPANION_LOYALTY: false for invalid tier name', () => {
+  const gs = makeGameState([makeCompanion('lyra', { loyalty: 100 })]);
+  assert.equal(checkCompanionObjective(gs, {
+    type: 'COMPANION_LOYALTY', companionId: 'lyra', minLoyaltyTier: 'FakeTier'
+  }), false);
+});
+
+test('checkCompanionObjective — COMPANION_SOULBOUND: true when soulbound', () => {
+  const gs = makeGameState([makeCompanion('lyra', { soulbound: true })]);
+  assert.equal(checkCompanionObjective(gs, {
+    type: 'COMPANION_SOULBOUND', companionId: 'lyra'
+  }), true);
+});
+
+test('checkCompanionObjective — COMPANION_SOULBOUND: false when not soulbound', () => {
+  const gs = makeGameState([makeCompanion('lyra')]);
+  assert.equal(checkCompanionObjective(gs, {
+    type: 'COMPANION_SOULBOUND', companionId: 'lyra'
+  }), false);
+});
+
+test('checkCompanionObjective — COMPANION_SOULBOUND: false when not in party', () => {
+  const gs = makeGameState([]);
+  assert.equal(checkCompanionObjective(gs, {
+    type: 'COMPANION_SOULBOUND', companionId: 'lyra'
+  }), false);
+});
+
+test('checkCompanionObjective — unknown type returns false', () => {
+  const gs = makeGameState([makeCompanion('lyra')]);
+  assert.equal(checkCompanionObjective(gs, {
+    type: 'UNKNOWN_TYPE', companionId: 'lyra'
+  }), false);
+});
+
+// ── onCompanionStateChange ─────────────────────────────────────────────
+
+// We need to mock getExplorationQuest for these tests.
+// Since quest-integration.js imports from exploration-quests.js, we need
+// quests that exist in the actual data. We'll test with a carefully
+// constructed questState that references a real quest ID but with
+// companion objectives injected. Since we can't modify quest data easily,
+// let's test the function behavior with edge cases.
+
+test('onCompanionStateChange — returns empty results for no active quests', () => {
+  const qs = makeQuestState();
+  const gs = makeGameState([makeCompanion('lyra')]);
+  const result = onCompanionStateChange(qs, gs);
+  assert.deepEqual(result.messages, []);
+  assert.deepEqual(result.completedObjectives, []);
+  assert.deepEqual(result.completedStages, []);
+  assert.deepEqual(result.completedQuests, []);
+});
+
+test('onCompanionStateChange — returns empty results for quest with no progress', () => {
+  const qs = makeQuestState({ activeQuests: ['explore_village'] });
+  const gs = makeGameState([makeCompanion('lyra')]);
+  const result = onCompanionStateChange(qs, gs);
+  // explore_village has EXPLORE objectives, not companion objectives
+  // so nothing should be updated
+  assert.deepEqual(result.completedObjectives, []);
+});
+
+test('onCompanionStateChange — handles quest with no matching quest data gracefully', () => {
+  const qs = makeQuestState({
+    activeQuests: ['nonexistent_quest'],
+    questProgress: { nonexistent_quest: { stageIndex: 0, objectiveProgress: {} } }
+  });
+  const gs = makeGameState([makeCompanion('lyra')]);
+  const result = onCompanionStateChange(qs, gs);
+  assert.deepEqual(result.messages, []);
+});
+
+test('onCompanionStateChange — does not modify questState when no companion objectives exist', () => {
+  const qs = makeQuestState({
+    activeQuests: ['explore_village'],
+    questProgress: { explore_village: { stageIndex: 0, objectiveProgress: {} } }
+  });
+  const gs = makeGameState([makeCompanion('lyra')]);
+  const result = onCompanionStateChange(qs, gs);
+  // questState should be structurally the same
+  assert.deepEqual(result.questState.activeQuests, ['explore_village']);
+});
+
+// ── acceptQuest with companion requirements (uses real quest data) ──────
+
+test('acceptQuest — works without gameState (backward compatible)', () => {
+  const qs = makeQuestState();
+  const result = acceptQuest(qs, 'explore_village');
+  assert.equal(result.accepted, true);
+  assert.ok(result.message.includes('Know Your Surroundings'));
+});
+
+test('acceptQuest — works with gameState when quest has no companion requirements', () => {
+  const qs = makeQuestState();
+  const gs = makeGameState([]);
+  const result = acceptQuest(qs, 'explore_village', gs);
+  assert.equal(result.accepted, true);
+});
+
+test('acceptQuest — still rejects unknown quests with gameState', () => {
+  const qs = makeQuestState();
+  const gs = makeGameState([makeCompanion('lyra')]);
+  const result = acceptQuest(qs, 'nonexistent', gs);
+  assert.equal(result.accepted, false);
+  assert.ok(result.message.includes('not found'));
+});
+
+test('acceptQuest — still rejects already active quests with gameState', () => {
+  const qs = makeQuestState({ activeQuests: ['explore_village'] });
+  const gs = makeGameState([makeCompanion('lyra')]);
+  const result = acceptQuest(qs, 'explore_village', gs);
+  assert.equal(result.accepted, false);
+  assert.ok(result.message.includes('already active'));
+});
+
+test('acceptQuest — still rejects already completed quests with gameState', () => {
+  const qs = makeQuestState({ completedQuests: ['explore_village'] });
+  const gs = makeGameState([makeCompanion('lyra')]);
+  const result = acceptQuest(qs, 'explore_village', gs);
+  assert.equal(result.accepted, false);
+  assert.ok(result.message.includes('already completed'));
+});
+
+test('acceptQuest — still checks prerequisites with gameState', () => {
+  const qs = makeQuestState();
+  const gs = makeGameState([makeCompanion('lyra')]);
+  const result = acceptQuest(qs, 'marsh_mystery', gs);
+  assert.equal(result.accepted, false);
+  assert.ok(result.message.includes('prerequisite'));
+});
+
+// ── describeCompanionRequirements ──────────────────────────────────────
+
+test('describeCompanionRequirements — returns empty for null/undefined quest', () => {
+  assert.deepEqual(describeCompanionRequirements(null), []);
+  assert.deepEqual(describeCompanionRequirements(undefined), []);
+});
+
+test('describeCompanionRequirements — returns empty for quest without requirements', () => {
+  assert.deepEqual(describeCompanionRequirements({ name: 'Test' }), []);
+});
+
+test('describeCompanionRequirements — returns empty for empty requirements array', () => {
+  assert.deepEqual(describeCompanionRequirements({ companionRequirements: [] }), []);
+});
+
+test('describeCompanionRequirements — describes inParty requirement', () => {
+  const result = describeCompanionRequirements({
+    companionRequirements: [{ companionId: 'lyra', inParty: true }]
+  });
+  assert.equal(result.length, 1);
+  assert.ok(result[0].includes('lyra'));
+  assert.ok(result[0].includes('party'));
+});
+
+test('describeCompanionRequirements — describes minLoyaltyTier requirement', () => {
+  const result = describeCompanionRequirements({
+    companionRequirements: [{ companionId: 'lyra', minLoyaltyTier: 'Devoted' }]
+  });
+  assert.equal(result.length, 1);
+  assert.ok(result[0].includes('Devoted'));
+});
+
+test('describeCompanionRequirements — describes soulbound requirement', () => {
+  const result = describeCompanionRequirements({
+    companionRequirements: [{ companionId: 'lyra', requireSoulbound: true }]
+  });
+  assert.equal(result.length, 1);
+  assert.ok(result[0].includes('soulbound'));
+});
+
+test('describeCompanionRequirements — describes combined requirements', () => {
+  const result = describeCompanionRequirements({
+    companionRequirements: [
+      { companionId: 'lyra', inParty: true, minLoyaltyTier: 'Devoted', requireSoulbound: true }
+    ]
+  });
+  assert.equal(result.length, 1);
+  assert.ok(result[0].includes('party'));
+  assert.ok(result[0].includes('Devoted'));
+  assert.ok(result[0].includes('soulbound'));
+});
+
+test('describeCompanionRequirements — multiple companions', () => {
+  const result = describeCompanionRequirements({
+    companionRequirements: [
+      { companionId: 'lyra', inParty: true },
+      { companionId: 'thorin', minLoyaltyTier: 'Friendly' }
+    ]
+  });
+  assert.equal(result.length, 2);
+});
+
+test('describeCompanionRequirements — filters out empty entries', () => {
+  const result = describeCompanionRequirements({
+    companionRequirements: [{ companionId: 'lyra' }] // no flags set
+  });
+  assert.equal(result.length, 0);
+});
+
+// ── LOYALTY_TIER_ORDER consistency ─────────────────────────────────────
+
+test('LOYALTY_TIER_ORDER has 6 tiers in ascending order', () => {
+  assert.equal(LOYALTY_TIER_ORDER.length, 6);
+  assert.deepEqual(LOYALTY_TIER_ORDER, [
+    'Abandoned', 'Discontent', 'Neutral', 'Friendly', 'Devoted', 'Soulbound'
+  ]);
+});
+
+test('LOYALTY_TIER_ORDER matches LOYALTY_TIERS names', () => {
+  for (let i = 0; i < LOYALTY_TIERS.length; i++) {
+    assert.equal(LOYALTY_TIER_ORDER[i], LOYALTY_TIERS[i].name);
+  }
+});
+
+// ── Edge cases and integration ─────────────────────────────────────────
+
+test('checkCompanionRequirements — loyalty at each tier boundary', () => {
+  const tierValues = [
+    { loyalty: 0, tier: 'Abandoned', index: 0 },
+    { loyalty: 10, tier: 'Discontent', index: 1 },
+    { loyalty: 25, tier: 'Neutral', index: 2 },
+    { loyalty: 50, tier: 'Friendly', index: 3 },
+    { loyalty: 75, tier: 'Devoted', index: 4 },
+    { loyalty: 100, tier: 'Soulbound', index: 5 }
+  ];
+
+  for (const { loyalty, tier } of tierValues) {
+    const gs = makeGameState([makeCompanion('lyra', { loyalty })]);
+    const result = checkCompanionRequirements(gs, [
+      { companionId: 'lyra', minLoyaltyTier: tier }
+    ]);
+    assert.equal(result.met, true, `Loyalty ${loyalty} should meet ${tier} tier`);
+  }
+});
+
+test('checkCompanionRequirements — loyalty just below each tier boundary fails', () => {
+  const tierBoundaries = [
+    { loyalty: 9, tier: 'Discontent' },
+    { loyalty: 24, tier: 'Neutral' },
+    { loyalty: 49, tier: 'Friendly' },
+    { loyalty: 74, tier: 'Devoted' },
+    { loyalty: 99, tier: 'Soulbound' }
+  ];
+
+  for (const { loyalty, tier } of tierBoundaries) {
+    const gs = makeGameState([makeCompanion('lyra', { loyalty })]);
+    const result = checkCompanionRequirements(gs, [
+      { companionId: 'lyra', minLoyaltyTier: tier }
+    ]);
+    assert.equal(result.met, false, `Loyalty ${loyalty} should NOT meet ${tier} tier`);
+  }
+});
+
+test('checkCompanionObjective — COMPANION_LOYALTY with loyalty exactly 0', () => {
+  const gs = makeGameState([makeCompanion('lyra', { loyalty: 0 })]);
+  assert.equal(checkCompanionObjective(gs, {
+    type: 'COMPANION_LOYALTY', companionId: 'lyra', minLoyaltyTier: 'Abandoned'
+  }), true);
+});
+
+test('checkCompanionObjective — COMPANION_LOYALTY with undefined loyalty defaults to 0', () => {
+  const gs = makeGameState([makeCompanion('lyra', { loyalty: undefined })]);
+  assert.equal(checkCompanionObjective(gs, {
+    type: 'COMPANION_LOYALTY', companionId: 'lyra', minLoyaltyTier: 'Abandoned'
+  }), true);
+  assert.equal(checkCompanionObjective(gs, {
+    type: 'COMPANION_LOYALTY', companionId: 'lyra', minLoyaltyTier: 'Discontent'
+  }), false);
+});
+
+// ── Test counter ───────────────────────────────────────────────────────
+
+let passed = 0;
+let failed = 0;
+
+test.after(() => {
+  // Node test runner handles counting, but we log for consistency
+});
+
+process.on('exit', () => {
+  console.log(`\nQuest Companion Requirements Tests complete.`);
+});


### PR DESCRIPTION
## Quest Companion Requirements + getLoyaltyTierIndex Defensive Fallback

### Summary
Adds the ability for quests to specify companion requirements — companions must be in the party, at a certain loyalty tier, or soulbound — both as quest-level acceptance gates and as stage-level objectives. Also addresses GPT-5.2's review nit from PR #156 about the `getLoyaltyTierIndex()` defensive fallback.

### Changes

**`src/companion-loyalty-events.js`**
- `getLoyaltyTierIndex()`: Added `|| 0` defensive fallback for future-proofing (addresses GPT-5.2's nit from PR #156)

**`src/quest-integration.js`** (5 new functions, 2 updated functions)
- **`checkCompanionRequirements(gameState, requirements)`** — Quest-level gate: checks if companion requirements (inParty, minLoyaltyTier, requireSoulbound) are met
- **`checkCompanionObjective(gameState, objective)`** — Stage-level: evaluates COMPANION_IN_PARTY, COMPANION_LOYALTY, COMPANION_SOULBOUND objective types
- **`onCompanionStateChange(questState, gameState)`** — Evaluates all companion-type objectives across active quests when party composition or loyalty changes
- **`describeCompanionRequirements(quest)`** — Returns human-readable description strings for UI display
- **`acceptQuest(questState, questId, gameState?)`** — Updated with optional 3rd parameter for companion requirement checking (backward compatible)
- **`getAvailableQuestsInRoom(questState, roomId, gameState?)`** — Updated with optional 3rd parameter (backward compatible)

**`tests/quest-companion-requirements-test.mjs`** — 64 new tests covering:
- getLoyaltyTierIndex defensive fallback (8 tests)
- checkCompanionRequirements: inParty, minLoyaltyTier, requireSoulbound, combined, multi-companion (18 tests)
- checkCompanionObjective: all 3 types + edge cases (13 tests)
- onCompanionStateChange: empty quests, missing data, no companion objectives (4 tests)
- acceptQuest backward compatibility with gameState (6 tests)
- describeCompanionRequirements: all variants (9 tests)
- LOYALTY_TIER_ORDER consistency (2 tests)
- Tier boundary edge cases (4 tests)

### New Objective Types for Quest Data
Quest authors can now use these objective types in stage definitions:
```js
{ type: 'COMPANION_IN_PARTY', id: 'have_lyra', companionId: 'lyra', description: 'Have Lyra in your party', required: true }
{ type: 'COMPANION_LOYALTY', id: 'lyra_devoted', companionId: 'lyra', minLoyaltyTier: 'Devoted', description: 'Earn Lyra\'s devotion', required: true }
{ type: 'COMPANION_SOULBOUND', id: 'lyra_soulbound', companionId: 'lyra', description: 'Form a soulbound with Lyra', required: true }
```

### Quest-Level Requirements
Quest definitions can now include:
```js
companionRequirements: [
  { companionId: 'lyra', inParty: true, minLoyaltyTier: 'Friendly' },
  { companionId: 'thorin', requireSoulbound: true }
]
```

### Test Results
- 64/64 new tests passing
- 71/71 existing quest-integration tests passing
- 67/67 loyalty-dialog-branching tests passing
- All backward compatible (no existing API changes)

### Note
GPT-5.2's PR #158 (TALK objectives) also modifies quest-integration.js. Whichever merges second will need a small rebase — both PRs are complementary and don't touch the same functions.
