### PR TITLE
fix: destructure companionAutoAct return value in handleEnemyTurnLogic

### DIFF
--- a/src/handlers/combat-handler.js
+++ b/src/handlers/combat-handler.js
@@ -94,14 +94,16 @@ export function handleEnemyTurnLogic(state) {
       let withGs = { ...next, gameStats: recordDamageReceived(next.gameStats || createGameStats(), dmgReceived) };
       // Companions auto-act after enemy turn (if still in combat)
       if (withGs.phase === 'player-turn' || withGs.phase === 'enemy-turn') {
-        withGs = companionAutoAct(withGs);
+        const autoResult = companionAutoAct(withGs);
+        withGs = autoResult.state;
       }
       return withGs;
     }
     
     // Companions auto-act after enemy turn (if still in combat)
     if (next.phase === 'player-turn' || next.phase === 'enemy-turn') {
-      return companionAutoAct(next);
+      const autoResult = companionAutoAct(next);
+      return autoResult.state;
     }
     return next;
 }


### PR DESCRIPTION
## Bug Fix: 'Unknown Phase: undefined' crash (Fixes #165, Fixes #148)

### Problem
`companionAutoAct()` returns `{ state, seed }` wrapper, but `handleEnemyTurnLogic` was assigning it directly to state. This replaced the game state with the wrapper object, causing `state.phase` and `state.log` to become `undefined`, triggering the 'Unknown Phase: undefined' crash.

### Root Cause
In `src/handlers/combat-handler.js`, two lines assigned `companionAutoAct()` directly:
- Line ~97 (damage received branch): `withGs = companionAutoAct(withGs);`
- Line ~104 (no damage branch): `return companionAutoAct(next);`

### Fix (4 lines changed)
Destructure the return value to extract `.state`:
```js
const autoResult = companionAutoAct(withGs);
withGs = autoResult.state;
```

### Why Basic Attack worked
`playerAttack` uses `companionsCombatTurn` (different function that returns raw state), not `companionAutoAct`. Only ability-based attacks (Fireball, etc.) triggered this path.

### Testing
- Reproduced bug: Mage -> Seek Battle -> Fireball -> crash
- After fix: combat continues normally
- All existing tests pass (3 pre-existing failures in crafting-integration-test.mjs are unrelated, present on main)