### PR TITLE
feat: specialization UI integration - choose path at level 5

### DIFF
--- a/src/handlers/ui-handler.js
+++ b/src/handlers/ui-handler.js
@@ -15,6 +15,7 @@ import { createShopState, buyItem, sellItem } from '../shop.js';
 import { createCraftingState, craftItem } from '../crafting.js';
 import { createTalentState, allocateTalent, deallocateTalent, resetAllTalents } from '../talents.js';
 import { recruitCompanion, dismissCompanion } from '../companions.js';
+import { shouldShowSpecialization, createSpecializationState, applySpecialization } from '../specialization-ui.js';
 
 function getRoomDescription(worldState) {
   const room = getCurrentRoom(worldState);
@@ -135,6 +136,18 @@ export function handleUIAction(state, action) {
     if (done) {
       const returnPhase = state.levelUpState.returnPhase || 'victory';
       if (returnPhase === 'battle-summary-done') {
+        // Check if player needs to choose a specialization
+        if (shouldShowSpecialization(state.player)) {
+          const specState = createSpecializationState(state.player);
+          let next2 = {
+            ...state,
+            phase: 'specialization',
+            specializationState: specState,
+            levelUpState: undefined,
+          };
+          next2 = pushLog(next2, 'You have reached the level of mastery! Choose your specialization path.');
+          return next2;
+        }
         const exits = getRoomExits(state.world);
         let next2 = {
           ...state,
@@ -163,6 +176,20 @@ export function handleUIAction(state, action) {
       return { ...state, phase: 'level-up', levelUpState: luState };
     }
     
+    // Check if player needs to choose a specialization (reached level 5+ without pending level-ups)
+    if (shouldShowSpecialization(state.player)) {
+      const specState = createSpecializationState(state.player);
+      let next = {
+        ...state,
+        phase: 'specialization',
+        specializationState: specState,
+        battleSummary: undefined,
+        pendingLevelUps: undefined,
+      };
+      next = pushLog(next, 'You have reached the level of mastery! Choose your specialization path.');
+      return next;
+    }
+
     // Return to exploration
     const exits = getRoomExits(state.world);
     let gs = state.gameStats || createGameStats();
@@ -425,6 +452,38 @@ export function handleUIAction(state, action) {
   }
   if (type === 'TAVERN_CASH_OUT') {
     return cashOutTavernDice(state);
+  }
+
+  // Specialization Choice
+  if (type === 'CHOOSE_SPECIALIZATION') {
+    if (state.phase !== 'specialization') return null;
+    const specId = action.specId;
+    if (!specId) return null;
+    
+    const updatedPlayer = applySpecialization(state.player, specId);
+    if (!updatedPlayer) return null;
+    
+    const exits = getRoomExits(state.world);
+    let gs = state.gameStats || createGameStats();
+    gs = recordBattleWon(gs);
+    if (state.enemy?.name) gs = recordEnemyDefeated(gs, state.enemy.name);
+    if ((state.xpGained ?? 0) > 0) gs = recordXPEarned(gs, state.xpGained);
+    if ((state.goldGained ?? 0) > 0) gs = recordGoldEarned(gs, state.goldGained);
+    
+    let next = {
+      ...state,
+      phase: 'exploration',
+      player: { ...updatedPlayer, defending: false },
+      specializationState: undefined,
+      battleSummary: undefined,
+      pendingLevelUps: undefined,
+      gameStats: gs,
+    };
+    const specName = action.specName || specId;
+    next = pushLog(next, 'You have chosen the path of the ' + specName + '!');
+    next = pushLog(next, 'New abilities and stat bonuses have been applied.');
+    next = pushLog(next, `${getRoomDescription(state.world)} Exits: ${exits.join(', ') || 'none'}.`);
+    return next;
   }
 
   return null;

--- a/src/render.js
+++ b/src/render.js
@@ -5,6 +5,7 @@ import { DEFAULT_WORLD_DATA, getRoomExits } from './map.js';
 import { getCategorizedInventory, getEquipmentDisplay, getItemDetails, INVENTORY_SCREENS, EQUIPMENT_SLOTS, getEquipmentBonuses } from './inventory.js';
 import { getEffectiveCombatStats, getEquipmentBonusDisplay, hasEquipmentBonuses } from './combat/equipment-bonuses.js';
 import { getCurrentLevelUp, getStatDiffs, formatStatName, xpForNextLevel } from './level-up.js';
+import { formatAbilityName } from './specialization-ui.js';
 import { getNPCsInRoom, getCurrentDialogLine, getDialogProgress } from './npc-dialog.js';
 import { getActiveQuestsSummary, getAvailableQuestsInRoom } from './quest-integration.js';
 import { getAbilityDisplayInfo } from './combat/abilities.js';
@@ -383,6 +384,62 @@ export function render(state, dispatch) {
       .reverse()
       .map((line) => `<div class="logLine">${esc(line)}</div>`)
       .join('');
+    finalizeRender();
+    return;
+  }
+
+
+  // --- Specialization Phase ---
+  if (state.phase === 'specialization' && state.specializationState) {
+    const specState = state.specializationState;
+    const choices = specState.choices || [];
+    const playerName = esc(specState.playerName || 'Hero');
+    const classId = specState.classId || '';
+    const className = classId.charAt(0).toUpperCase() + classId.slice(1);
+
+    const choiceCards = choices.map((choice, idx) => {
+      const statLines = choice.statBonuses.map(sb => {
+        const color = sb.value > 0 ? '#4f4' : '#f44';
+        return '<div style="color:' + color + ';">' + esc(sb.formatted) + '</div>';
+      }).join('');
+      const abilityLines = choice.abilities.map(a =>
+        '<div>\u2694\uFE0F ' + esc(a.name) + '</div>'
+      ).join('');
+      const passiveHtml = choice.passive
+        ? '<div style="margin-top:6px;"><b>\u2728 ' + esc(choice.passive.name) + '</b></div>'
+          + '<div style="font-size:0.85em;opacity:0.8;">' + esc(choice.passive.description) + '</div>'
+        : '';
+      return '<div class="card" style="flex:1;min-width:220px;cursor:pointer;border:2px solid #555;" '
+        + 'id="specChoice' + idx + '">'
+        + '<h3 style="color:#ffd700;">' + esc(choice.name) + '</h3>'
+        + '<div style="font-size:0.9em;opacity:0.85;margin-bottom:8px;">' + esc(choice.description) + '</div>'
+        + '<div style="margin-bottom:6px;"><b>Stat Bonuses:</b></div>' + statLines
+        + '<div style="margin-top:6px;margin-bottom:6px;"><b>New Abilities:</b></div>' + abilityLines
+        + passiveHtml
+        + '</div>';
+    }).join('');
+
+    hud.innerHTML = '<div class="row">'
+      + '<div class="card" style="width:100%;text-align:center;">'
+      + '<h2 style="color:#ffd700;">\u2B50 Specialization Unlocked!</h2>'
+      + '<div>' + playerName + ' the ' + esc(className) + ' has reached Level 5!</div>'
+      + '<div style="margin-top:4px;">Choose your path wisely — this choice is permanent.</div>'
+      + '</div></div>'
+      + '<div class="row" style="gap:12px;">' + choiceCards + '</div>';
+
+    actions.innerHTML = '';
+
+    // Wire up click handlers
+    choices.forEach((choice, idx) => {
+      const el = document.getElementById('specChoice' + idx);
+      if (el) {
+        el.onmouseenter = () => { el.style.borderColor = '#ffd700'; };
+        el.onmouseleave = () => { el.style.borderColor = '#555'; };
+        el.onclick = () => dispatch({ type: 'CHOOSE_SPECIALIZATION', specId: choice.id, specName: choice.name });
+      }
+    });
+
+    log.innerHTML = state.log.slice().reverse().map(line => '<div class="logLine">' + esc(line) + '</div>').join('');
     finalizeRender();
     return;
   }

--- a/src/specialization-ui.js
+++ b/src/specialization-ui.js
@@ -1,0 +1,101 @@
+import {
+  SPECIALIZATION_LEVEL,
+  getSpecializationsForClass,
+  getSpecialization,
+  canSpecialize,
+  applySpecialization,
+  isSpecialized,
+} from './class-specializations.js';
+import { formatStatName } from './level-up.js';
+
+/**
+ * Convert a kebab-case ability id into Title Case.
+ *
+ * @param {string} abilityId
+ * @returns {string}
+ */
+export function formatAbilityName(abilityId) {
+  if (!abilityId) {
+    return '';
+  }
+  return String(abilityId)
+    .split('-')
+    .filter(Boolean)
+    .map((segment) => segment.charAt(0).toUpperCase() + segment.slice(1))
+    .join(' ');
+}
+
+/**
+ * Determine if the specialization choice UI should be shown.
+ *
+ * @param {object} player
+ * @returns {boolean}
+ */
+export function shouldShowSpecialization(player) {
+  if (!player) {
+    return false;
+  }
+  return (
+    Number(player.level ?? 0) >= SPECIALIZATION_LEVEL &&
+    !player.specialization &&
+    Boolean(player.classId)
+  );
+}
+
+const formatStatBonus = (stat, value) => ({
+  stat,
+  value,
+  formatted: `${value > 0 ? '+' : ''}${value} ${formatStatName(stat)}`,
+});
+
+/**
+ * Build specialization choices for a class, ready for rendering.
+ *
+ * @param {string} classId
+ * @returns {Array<{id: string, name: string, description: string, statBonuses: Array<{stat: string, value: number, formatted: string}>, abilities: Array<{id: string, name: string}>, passive: {id: string, name: string, description: string} | null}>}
+ */
+export function getSpecializationChoices(classId) {
+  return getSpecializationsForClass(classId).map((spec) => ({
+    id: spec.id,
+    name: spec.name,
+    description: spec.description,
+    statBonuses: Object.entries(spec.statBonuses ?? {}).map(([stat, value]) =>
+      formatStatBonus(stat, value)
+    ),
+    abilities: (spec.abilities ?? []).map((abilityId) => ({
+      id: abilityId,
+      name: formatAbilityName(abilityId),
+    })),
+    passive: spec.passive
+      ? {
+          id: spec.passive.id,
+          name: spec.passive.name,
+          description: spec.passive.description,
+        }
+      : null,
+  }));
+}
+
+/**
+ * Create UI state for specialization selection.
+ *
+ * @param {object} player
+ * @returns {{classId: string | null, choices: Array<{id: string, name: string, description: string, statBonuses: Array<{stat: string, value: number, formatted: string}>, abilities: Array<{id: string, name: string}>, passive: {id: string, name: string, description: string} | null}>, playerName: string | null}}
+ */
+export function createSpecializationState(player) {
+  const classId = player?.classId ?? null;
+  return {
+    classId,
+    choices: classId ? getSpecializationChoices(classId) : [],
+    playerName: player?.name ?? null,
+  };
+}
+
+export {
+  SPECIALIZATION_LEVEL,
+  getSpecializationsForClass,
+  getSpecialization,
+  canSpecialize,
+  applySpecialization,
+  isSpecialized,
+};

--- a/tests/specialization-ui-test.mjs
+++ b/tests/specialization-ui-test.mjs
@@ -1,0 +1,303 @@
+/**
+ * Tests for specialization-ui.js — Pure functions for specialization choice UI.
+ * Tests formatAbilityName, shouldShowSpecialization, getSpecializationChoices,
+ * createSpecializationState, and the integration with ui-handler.js for
+ * CHOOSE_SPECIALIZATION action.
+ */
+
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import {
+  formatAbilityName,
+  shouldShowSpecialization,
+  getSpecializationChoices,
+  createSpecializationState,
+} from '../src/specialization-ui.js';
+
+import { SPECIALIZATION_LEVEL, applySpecialization } from '../src/class-specializations.js';
+
+// ─── formatAbilityName ───────────────────────────────────────────
+
+describe('formatAbilityName', () => {
+  it('converts single word to Title Case', () => {
+    assert.equal(formatAbilityName('frenzy'), 'Frenzy');
+  });
+
+  it('converts kebab-case to Title Case words', () => {
+    assert.equal(formatAbilityName('reckless-strike'), 'Reckless Strike');
+  });
+
+  it('handles multi-part kebab-case', () => {
+    assert.equal(formatAbilityName('chain-lightning'), 'Chain Lightning');
+  });
+
+  it('returns empty string for null/undefined', () => {
+    assert.equal(formatAbilityName(null), '');
+    assert.equal(formatAbilityName(undefined), '');
+  });
+
+  it('returns empty string for empty string', () => {
+    assert.equal(formatAbilityName(''), '');
+  });
+
+  it('handles already capitalized input', () => {
+    assert.equal(formatAbilityName('Frenzy'), 'Frenzy');
+  });
+});
+
+// ─── shouldShowSpecialization ────────────────────────────────────
+
+describe('shouldShowSpecialization', () => {
+  it('returns true when player is at specialization level with classId and no specialization', () => {
+    const player = { level: SPECIALIZATION_LEVEL, classId: 'warrior', specialization: null };
+    assert.equal(shouldShowSpecialization(player), true);
+  });
+
+  it('returns true when player is above specialization level', () => {
+    const player = { level: SPECIALIZATION_LEVEL + 3, classId: 'mage', specialization: undefined };
+    assert.equal(shouldShowSpecialization(player), true);
+  });
+
+  it('returns false when player is below specialization level', () => {
+    const player = { level: SPECIALIZATION_LEVEL - 1, classId: 'warrior' };
+    assert.equal(shouldShowSpecialization(player), false);
+  });
+
+  it('returns false when player already has a specialization', () => {
+    const player = { level: SPECIALIZATION_LEVEL, classId: 'warrior', specialization: 'berserker' };
+    assert.equal(shouldShowSpecialization(player), false);
+  });
+
+  it('returns false when player has no classId', () => {
+    const player = { level: SPECIALIZATION_LEVEL };
+    assert.equal(shouldShowSpecialization(player), false);
+  });
+
+  it('returns false for null player', () => {
+    assert.equal(shouldShowSpecialization(null), false);
+  });
+
+  it('returns false for undefined player', () => {
+    assert.equal(shouldShowSpecialization(undefined), false);
+  });
+
+  it('returns false when level is missing (defaults to 0)', () => {
+    const player = { classId: 'rogue' };
+    assert.equal(shouldShowSpecialization(player), false);
+  });
+});
+
+// ─── getSpecializationChoices ────────────────────────────────────
+
+describe('getSpecializationChoices', () => {
+  it('returns two choices for warrior class', () => {
+    const choices = getSpecializationChoices('warrior');
+    assert.equal(choices.length, 2);
+    const ids = choices.map(c => c.id);
+    assert.ok(ids.includes('berserker'), 'Should include berserker');
+    assert.ok(ids.includes('guardian'), 'Should include guardian');
+  });
+
+  it('returns two choices for mage class', () => {
+    const choices = getSpecializationChoices('mage');
+    assert.equal(choices.length, 2);
+    const ids = choices.map(c => c.id);
+    assert.ok(ids.includes('elementalist'));
+    assert.ok(ids.includes('enchanter'));
+  });
+
+  it('returns two choices for rogue class', () => {
+    const choices = getSpecializationChoices('rogue');
+    assert.equal(choices.length, 2);
+    const ids = choices.map(c => c.id);
+    assert.ok(ids.includes('assassin'));
+    assert.ok(ids.includes('shadow'));
+  });
+
+  it('returns two choices for cleric class', () => {
+    const choices = getSpecializationChoices('cleric');
+    assert.equal(choices.length, 2);
+    const ids = choices.map(c => c.id);
+    assert.ok(ids.includes('paladin'));
+    assert.ok(ids.includes('oracle'));
+  });
+
+  it('returns empty array for unknown class', () => {
+    const choices = getSpecializationChoices('necromancer');
+    assert.equal(choices.length, 0);
+  });
+
+  it('each choice has required fields', () => {
+    const choices = getSpecializationChoices('warrior');
+    for (const choice of choices) {
+      assert.ok(typeof choice.id === 'string', 'id should be string');
+      assert.ok(typeof choice.name === 'string', 'name should be string');
+      assert.ok(typeof choice.description === 'string', 'description should be string');
+      assert.ok(Array.isArray(choice.statBonuses), 'statBonuses should be array');
+      assert.ok(Array.isArray(choice.abilities), 'abilities should be array');
+      assert.ok(choice.passive !== undefined, 'passive should exist');
+    }
+  });
+
+  it('stat bonuses have formatted field with sign prefix', () => {
+    const choices = getSpecializationChoices('warrior');
+    const berserker = choices.find(c => c.id === 'berserker');
+    assert.ok(berserker, 'berserker should exist');
+    // berserker has atk: 4 (positive) and def: -2 (negative)
+    const atkBonus = berserker.statBonuses.find(sb => sb.stat === 'atk');
+    assert.ok(atkBonus, 'atk bonus should exist');
+    assert.ok(atkBonus.formatted.startsWith('+'), 'positive stat should start with +');
+    assert.ok(atkBonus.value > 0, 'atk value should be positive');
+
+    const defBonus = berserker.statBonuses.find(sb => sb.stat === 'def');
+    assert.ok(defBonus, 'def bonus should exist');
+    assert.ok(defBonus.value < 0, 'def value should be negative');
+    assert.ok(!defBonus.formatted.startsWith('+'), 'negative stat should not start with +');
+  });
+
+  it('abilities have id and formatted name', () => {
+    const choices = getSpecializationChoices('warrior');
+    const berserker = choices.find(c => c.id === 'berserker');
+    assert.ok(berserker.abilities.length >= 2, 'berserker should have at least 2 abilities');
+    for (const ability of berserker.abilities) {
+      assert.ok(typeof ability.id === 'string', 'ability id should be string');
+      assert.ok(typeof ability.name === 'string', 'ability name should be string');
+      // Name should be Title Case (first letter uppercase)
+      assert.ok(ability.name.charAt(0) === ability.name.charAt(0).toUpperCase(),
+        'ability name should start with uppercase');
+    }
+  });
+
+  it('passive has id, name, and description', () => {
+    const choices = getSpecializationChoices('mage');
+    const elementalist = choices.find(c => c.id === 'elementalist');
+    assert.ok(elementalist.passive, 'elementalist should have a passive');
+    assert.ok(typeof elementalist.passive.id === 'string');
+    assert.ok(typeof elementalist.passive.name === 'string');
+    assert.ok(typeof elementalist.passive.description === 'string');
+  });
+});
+
+// ─── createSpecializationState ───────────────────────────────────
+
+describe('createSpecializationState', () => {
+  it('creates state with classId, choices, and playerName', () => {
+    const player = { classId: 'warrior', name: 'TestHero', level: 5 };
+    const state = createSpecializationState(player);
+    assert.equal(state.classId, 'warrior');
+    assert.equal(state.playerName, 'TestHero');
+    assert.equal(state.choices.length, 2);
+  });
+
+  it('handles null player gracefully', () => {
+    const state = createSpecializationState(null);
+    assert.equal(state.classId, null);
+    assert.equal(state.playerName, null);
+    assert.equal(state.choices.length, 0);
+  });
+
+  it('handles player without classId', () => {
+    const player = { name: 'NoClass', level: 5 };
+    const state = createSpecializationState(player);
+    assert.equal(state.classId, null);
+    assert.equal(state.choices.length, 0);
+  });
+
+  it('creates correct choices for each class', () => {
+    for (const classId of ['warrior', 'mage', 'rogue', 'cleric']) {
+      const player = { classId, name: 'Hero', level: 5 };
+      const state = createSpecializationState(player);
+      assert.equal(state.classId, classId);
+      assert.equal(state.choices.length, 2, `${classId} should have 2 choices`);
+    }
+  });
+});
+
+// ─── Integration: applySpecialization with UI flow ───────────────
+
+describe('Specialization UI integration with applySpecialization', () => {
+  it('applying berserker specialization modifies player stats correctly', () => {
+    const player = {
+      classId: 'warrior',
+      class: 'warrior',
+      name: 'TestWarrior',
+      level: 5,
+      stats: { maxHp: 80, maxMp: 20, atk: 15, def: 12, spd: 8, int: 5, lck: 5 },
+      specialization: null,
+      abilities: ['power-strike'],
+    };
+    const result = applySpecialization(player, 'berserker');
+    assert.ok(result, 'applySpecialization should return a result');
+    assert.equal(result.specialization, 'berserker');
+    // Berserker: atk +4, spd +2, def -2
+    assert.equal(result.stats.atk, 19); // 15 + 4
+    assert.equal(result.stats.spd, 10); // 8 + 2
+    assert.equal(result.stats.def, 10); // 12 - 2
+  });
+
+  it('applying guardian specialization modifies player stats correctly', () => {
+    const player = {
+      classId: 'warrior',
+      class: 'warrior',
+      name: 'TestWarrior',
+      level: 5,
+      stats: { maxHp: 80, maxMp: 20, atk: 15, def: 12, spd: 8, int: 5, lck: 5 },
+      specialization: null,
+      abilities: ['power-strike'],
+    };
+    const result = applySpecialization(player, 'guardian');
+    assert.ok(result);
+    assert.equal(result.specialization, 'guardian');
+    // Guardian: def +5, maxHp +15, spd -1
+    assert.equal(result.stats.def, 17); // 12 + 5
+    assert.equal(result.stats.maxHp, 95); // 80 + 15
+    assert.equal(result.stats.spd, 7); // 8 - 1
+  });
+
+  it('shouldShowSpecialization returns false after applying specialization', () => {
+    const player = {
+      classId: 'warrior',
+      class: 'warrior',
+      name: 'TestWarrior',
+      level: 5,
+      stats: { maxHp: 80, maxMp: 20, atk: 15, def: 12, spd: 8, int: 5, lck: 5 },
+      specialization: null,
+      abilities: ['power-strike'],
+    };
+    assert.equal(shouldShowSpecialization(player), true);
+    const result = applySpecialization(player, 'berserker');
+    assert.equal(shouldShowSpecialization(result), false);
+  });
+
+  it('full flow: create state, get choices, verify structure, apply', () => {
+    const player = {
+      classId: 'rogue',
+      class: 'rogue',
+      name: 'TestRogue',
+      level: 5,
+      stats: { maxHp: 60, maxMp: 30, atk: 12, def: 8, spd: 14, int: 7, lck: 10 },
+      specialization: null,
+      abilities: ['backstab'],
+    };
+    
+    // Step 1: Check should show
+    assert.equal(shouldShowSpecialization(player), true);
+    
+    // Step 2: Create state
+    const specState = createSpecializationState(player);
+    assert.equal(specState.choices.length, 2);
+    
+    // Step 3: Find assassin choice
+    const assassin = specState.choices.find(c => c.id === 'assassin');
+    assert.ok(assassin, 'assassin choice should exist');
+    assert.ok(assassin.statBonuses.length > 0, 'should have stat bonuses');
+    assert.ok(assassin.abilities.length >= 2, 'should have abilities');
+    assert.ok(assassin.passive, 'should have passive');
+    
+    // Step 4: Apply
+    const result = applySpecialization(player, 'assassin');
+    assert.equal(result.specialization, 'assassin');
+    assert.equal(shouldShowSpecialization(result), false);
+  });
+});


### PR DESCRIPTION
## Specialization UI Integration

Adds a complete specialization choice UI that triggers when a player reaches level 5 after combat. Players see both specialization options for their class with stat bonuses, new abilities, and passive effects, then click to choose their permanent path.

### New files
- **src/specialization-ui.js**: Pure functions for specialization choice data
  - `shouldShowSpecialization(player)`: checks if UI should show
  - `getSpecializationChoices(classId)`: builds display-ready choice objects
  - `createSpecializationState(player)`: creates UI state
  - `formatAbilityName(id)`: kebab-case to Title Case
- **tests/specialization-ui-test.mjs**: 31 comprehensive tests (all passing)

### Modified files
- **src/handlers/ui-handler.js**: CHOOSE_SPECIALIZATION action handler, hooks into level-up-done and battle-summary-done flows
- **src/render.js**: New specialization phase rendering with interactive choice cards showing stat bonuses (color-coded green/red), abilities, passives

### Game Flow
combat victory → battle-summary → level-up → **specialization choice** → exploration

The specialization screen only appears once (when level >= 5 and no spec chosen). Choice is permanent. Builds on PR #183 (class-specializations.js backend).

### Tests
31 tests covering: formatAbilityName, shouldShowSpecialization, getSpecializationChoices, createSpecializationState, and integration with applySpecialization. All tests pass.