### PR TITLE
feat: add dungeon floor progression system (10 floors, 73 tests)

### DIFF
--- a/src/dungeon-floors.js
+++ b/src/dungeon-floors.js
@@ -1,0 +1,283 @@
+export const DUNGEON_FLOORS = [
+  {
+    id: 1,
+    name: "Echoing Grotto",
+    theme: "cavern",
+    description: "Damp tunnels where slimes and bats cling to stone.",
+    enemyPool: ["slime", "cave_bat", "goblin"],
+    difficultyMultiplier: 1.0,
+    encounterRate: 0.3,
+    bossFloor: false,
+    bossId: null,
+    minLevel: 3,
+  },
+  {
+    id: 2,
+    name: "Crystal Hollows",
+    theme: "cavern",
+    description: "Glittering caverns hide skittering fangs and ambushers.",
+    enemyPool: ["slime", "cave_bat", "goblin", "giant_spider"],
+    difficultyMultiplier: 1.15,
+    encounterRate: 0.33,
+    bossFloor: false,
+    bossId: null,
+    minLevel: 4,
+  },
+  {
+    id: 3,
+    name: "Goblin Stronghold",
+    theme: "goblin_stronghold",
+    description: "Barricaded caves echo with drums and goblin war cries.",
+    enemyPool: ["goblin", "goblin_chief", "cave_bat"],
+    difficultyMultiplier: 1.3,
+    encounterRate: 0.36,
+    bossFloor: true,
+    bossId: "goblin_chief",
+    minLevel: 5,
+  },
+  {
+    id: 4,
+    name: "Silent Catacombs",
+    theme: "crypt",
+    description: "Ancient bones and cold mist rise from unmarked graves.",
+    enemyPool: ["skeleton", "wraith", "dark-cultist"],
+    difficultyMultiplier: 1.45,
+    encounterRate: 0.4,
+    bossFloor: false,
+    bossId: null,
+    minLevel: 6,
+  },
+  {
+    id: 5,
+    name: "Shattered Mausoleum",
+    theme: "crypt",
+    description: "Cursed halls where spirits guard forgotten relics.",
+    enemyPool: ["skeleton", "wraith", "dark-cultist", "orc"],
+    difficultyMultiplier: 1.6,
+    encounterRate: 0.44,
+    bossFloor: false,
+    bossId: null,
+    minLevel: 7,
+  },
+  {
+    id: 6,
+    name: "Frozen Depths",
+    theme: "frozen_depths",
+    description: "Ice-choked passages where frost bites through armor.",
+    enemyPool: ["ice-spirit", "wolf", "skeleton"],
+    difficultyMultiplier: 1.75,
+    encounterRate: 0.48,
+    bossFloor: true,
+    bossId: "ice-spirit",
+    minLevel: 8,
+  },
+  {
+    id: 7,
+    name: "Ruined Causeway",
+    theme: "ruins",
+    description: "Broken stone bridges patrolled by hardened raiders.",
+    enemyPool: ["stone-golem", "orc", "bandit"],
+    difficultyMultiplier: 1.9,
+    encounterRate: 0.52,
+    bossFloor: false,
+    bossId: null,
+    minLevel: 9,
+  },
+  {
+    id: 8,
+    name: "Forgotten Bastion",
+    theme: "ruins",
+    description: "Collapsed keeps shelter warbands and ancient sentries.",
+    enemyPool: ["stone-golem", "orc", "bandit", "wraith"],
+    difficultyMultiplier: 2.05,
+    encounterRate: 0.56,
+    bossFloor: false,
+    bossId: null,
+    minLevel: 10,
+  },
+  {
+    id: 9,
+    name: "Infernal Gate",
+    theme: "inferno",
+    description: "Molten chambers blaze with stormfire and winged hunters.",
+    enemyPool: ["fire-spirit", "thunder-hawk", "dragon"],
+    difficultyMultiplier: 2.2,
+    encounterRate: 0.6,
+    bossFloor: true,
+    bossId: "dragon",
+    minLevel: 11,
+  },
+  {
+    id: 10,
+    name: "Abyssal Throne",
+    theme: "abyss",
+    description: "The final descent where every terror gathers.",
+    enemyPool: [
+      "slime",
+      "goblin",
+      "goblin_chief",
+      "cave_bat",
+      "giant_spider",
+      "wolf",
+      "skeleton",
+      "orc",
+      "fire-spirit",
+      "ice-spirit",
+      "dark-cultist",
+      "bandit",
+      "wraith",
+      "stone-golem",
+      "thunder-hawk",
+      "dragon",
+    ],
+    difficultyMultiplier: 2.35,
+    encounterRate: 0.65,
+    bossFloor: true,
+    bossId: "abyss_overlord",
+    minLevel: 12,
+  },
+];
+
+const TOTAL_FLOORS = 10;
+
+export function createDungeonState() {
+  return {
+    currentFloor: 0,
+    deepestFloor: 0,
+    floorsCleared: [],
+    inDungeon: false,
+    stairsFound: false,
+  };
+}
+
+export function enterDungeon(dungeonState) {
+  return {
+    ...dungeonState,
+    inDungeon: true,
+    currentFloor: 1,
+    stairsFound: false,
+  };
+}
+
+export function exitDungeon(dungeonState) {
+  return {
+    ...dungeonState,
+    inDungeon: false,
+    currentFloor: 0,
+    stairsFound: false,
+  };
+}
+
+export function getFloorData(floorNumber) {
+  return DUNGEON_FLOORS.find((floor) => floor.id === floorNumber) || null;
+}
+
+export function advanceFloor(dungeonState) {
+  const nextFloor = Math.min(dungeonState.currentFloor + 1, TOTAL_FLOORS);
+  return {
+    ...dungeonState,
+    currentFloor: nextFloor,
+    deepestFloor: Math.max(dungeonState.deepestFloor, nextFloor),
+    stairsFound: false,
+  };
+}
+
+export function clearFloor(dungeonState) {
+  const currentFloor = dungeonState.currentFloor;
+  if (!currentFloor) {
+    return { ...dungeonState };
+  }
+  if (dungeonState.floorsCleared.includes(currentFloor)) {
+    return { ...dungeonState };
+  }
+  return {
+    ...dungeonState,
+    floorsCleared: [...dungeonState.floorsCleared, currentFloor],
+  };
+}
+
+export function findStairs(dungeonState) {
+  return {
+    ...dungeonState,
+    stairsFound: true,
+  };
+}
+
+export function canAdvance(dungeonState) {
+  if (!dungeonState.stairsFound) {
+    return false;
+  }
+  const floorData = getFloorData(dungeonState.currentFloor);
+  if (!floorData) {
+    return false;
+  }
+  const cleared = dungeonState.floorsCleared.includes(dungeonState.currentFloor);
+  return cleared || floorData.bossFloor;
+}
+
+export function getScaledEnemy(enemy, floorNumber) {
+  const floorData = getFloorData(floorNumber);
+  if (!floorData || !enemy) {
+    return enemy ? { ...enemy } : null;
+  }
+  const multiplier = floorData.difficultyMultiplier;
+  const scale = (value) => Math.max(1, Math.round(value * multiplier));
+  return {
+    ...enemy,
+    hp: scale(enemy.hp),
+    maxHp: scale(enemy.maxHp ?? enemy.hp),
+    atk: scale(enemy.atk),
+    def: scale(enemy.def),
+    spd: scale(enemy.spd),
+    xpReward: scale(enemy.xpReward),
+    goldReward: scale(enemy.goldReward),
+  };
+}
+
+export function getRandomEncounter(dungeonState, rngSeed) {
+  const floorData = getFloorData(dungeonState.currentFloor);
+  if (!floorData || !rngSeed) {
+    return null;
+  }
+  const nextSeed = (rngSeed * 16807) % 2147483647;
+  const roll = nextSeed / 2147483647;
+  if (roll > floorData.encounterRate) {
+    return null;
+  }
+  const poolIndex = Math.floor(roll * floorData.enemyPool.length);
+  const enemyId = floorData.enemyPool[poolIndex];
+  return { enemyId, seed: nextSeed };
+}
+
+export function getDungeonProgress(dungeonState) {
+  const floorsCleared = dungeonState.floorsCleared.length;
+  const percentComplete = Math.min(
+    100,
+    Math.round((floorsCleared / TOTAL_FLOORS) * 100)
+  );
+  return {
+    currentFloor: dungeonState.currentFloor,
+    deepestFloor: dungeonState.deepestFloor,
+    floorsCleared,
+    totalFloors: TOTAL_FLOORS,
+    percentComplete,
+  };
+}
+
+export function isFloorCleared(dungeonState, floorNumber) {
+  return dungeonState.floorsCleared.includes(floorNumber);
+}
+
+export function getFloorTheme(floorNumber) {
+  const floorData = getFloorData(floorNumber);
+  return floorData ? floorData.theme : null;
+}
+
+export function canEnterDungeon(playerLevel) {
+  return playerLevel >= 3;
+}
+
+export function getBossForFloor(floorNumber) {
+  const floorData = getFloorData(floorNumber);
+  return floorData ? floorData.bossId : null;
+}

--- a/tests/dungeon-floors-test.mjs
+++ b/tests/dungeon-floors-test.mjs
@@ -1,0 +1,504 @@
+/**
+ * Dungeon Floors Tests — AI Village RPG
+ * Run: node tests/dungeon-floors-test.mjs
+ */
+
+import { describe, test } from 'node:test';
+import assert from 'node:assert/strict';
+import * as dungeon from '../src/dungeon-floors.js';
+
+const {
+  DUNGEON_FLOORS,
+  createDungeonState,
+  enterDungeon,
+  exitDungeon,
+  getFloorData,
+  advanceFloor,
+  clearFloor,
+  findStairs,
+  canAdvance,
+  getScaledEnemy,
+  getRandomEncounter,
+  getDungeonProgress,
+  isFloorCleared,
+  getFloorTheme,
+  canEnterDungeon,
+  getBossForFloor,
+} = dungeon;
+
+const clone = (value) => JSON.parse(JSON.stringify(value));
+
+const requiredFields = [
+  'id',
+  'name',
+  'theme',
+  'description',
+  'enemyPool',
+  'difficultyMultiplier',
+  'encounterRate',
+  'bossFloor',
+  'bossId',
+  'minLevel',
+];
+
+const makeState = (overrides = {}) => ({
+  currentFloor: 0,
+  deepestFloor: 0,
+  floorsCleared: [],
+  inDungeon: false,
+  stairsFound: false,
+  ...overrides,
+});
+
+const getRoll = (seed) => ((seed * 16807) % 2147483647) / 2147483647;
+
+describe('DUNGEON_FLOORS', () => {
+  test('has exactly 10 floors', () => {
+    assert.equal(DUNGEON_FLOORS.length, 10);
+  });
+
+  test('each floor has required fields', () => {
+    for (const floor of DUNGEON_FLOORS) {
+      for (const field of requiredFields) {
+        assert.ok(Object.prototype.hasOwnProperty.call(floor, field));
+      }
+    }
+  });
+
+  test('floor IDs are sequential 1-10', () => {
+    const ids = DUNGEON_FLOORS.map((floor) => floor.id);
+    assert.deepEqual(ids, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+  });
+
+  test('boss floors are 3, 6, 9, 10', () => {
+    const bossFloors = DUNGEON_FLOORS.filter((floor) => floor.bossFloor).map(
+      (floor) => floor.id
+    );
+    assert.deepEqual(bossFloors, [3, 6, 9, 10]);
+  });
+
+  test('non-boss floors have bossId null', () => {
+    for (const floor of DUNGEON_FLOORS) {
+      if (!floor.bossFloor) {
+        assert.equal(floor.bossId, null);
+      }
+    }
+  });
+
+  test('difficultyMultiplier increases with floor number', () => {
+    for (let i = 1; i < DUNGEON_FLOORS.length; i += 1) {
+      assert.ok(
+        DUNGEON_FLOORS[i].difficultyMultiplier >
+          DUNGEON_FLOORS[i - 1].difficultyMultiplier
+      );
+    }
+  });
+
+  test('encounterRate increases with floor number', () => {
+    for (let i = 1; i < DUNGEON_FLOORS.length; i += 1) {
+      assert.ok(
+        DUNGEON_FLOORS[i].encounterRate > DUNGEON_FLOORS[i - 1].encounterRate
+      );
+    }
+  });
+
+  test('minLevel increases with floor number', () => {
+    for (let i = 1; i < DUNGEON_FLOORS.length; i += 1) {
+      assert.ok(DUNGEON_FLOORS[i].minLevel > DUNGEON_FLOORS[i - 1].minLevel);
+    }
+  });
+
+  test('enemyPool entries are strings', () => {
+    for (const floor of DUNGEON_FLOORS) {
+      for (const entry of floor.enemyPool) {
+        assert.equal(typeof entry, 'string');
+      }
+    }
+  });
+});
+
+describe('createDungeonState()', () => {
+  test('returns an object with expected keys', () => {
+    const state = createDungeonState();
+    assert.deepEqual(Object.keys(state).sort(), [
+      'currentFloor',
+      'deepestFloor',
+      'floorsCleared',
+      'inDungeon',
+      'stairsFound',
+    ]);
+  });
+
+  test('currentFloor is 0', () => {
+    assert.equal(createDungeonState().currentFloor, 0);
+  });
+
+  test('inDungeon is false', () => {
+    assert.equal(createDungeonState().inDungeon, false);
+  });
+
+  test('floorsCleared is empty array', () => {
+    assert.deepEqual(createDungeonState().floorsCleared, []);
+  });
+
+  test('stairsFound is false', () => {
+    assert.equal(createDungeonState().stairsFound, false);
+  });
+});
+
+describe('enterDungeon(state)', () => {
+  test('sets inDungeon to true', () => {
+    const result = enterDungeon(makeState());
+    assert.equal(result.inDungeon, true);
+  });
+
+  test('sets currentFloor to 1', () => {
+    const result = enterDungeon(makeState());
+    assert.equal(result.currentFloor, 1);
+  });
+
+  test('resets stairsFound to false', () => {
+    const result = enterDungeon(makeState({ stairsFound: true }));
+    assert.equal(result.stairsFound, false);
+  });
+
+  test('does not mutate input', () => {
+    const original = makeState({ stairsFound: true, currentFloor: 4 });
+    const snapshot = clone(original);
+    enterDungeon(original);
+    assert.deepEqual(original, snapshot);
+  });
+});
+
+describe('exitDungeon(state)', () => {
+  test('sets inDungeon to false', () => {
+    const result = exitDungeon(makeState({ inDungeon: true }));
+    assert.equal(result.inDungeon, false);
+  });
+
+  test('sets currentFloor to 0', () => {
+    const result = exitDungeon(makeState({ currentFloor: 5 }));
+    assert.equal(result.currentFloor, 0);
+  });
+
+  test('does not mutate input', () => {
+    const original = makeState({ inDungeon: true, currentFloor: 5 });
+    const snapshot = clone(original);
+    exitDungeon(original);
+    assert.deepEqual(original, snapshot);
+  });
+});
+
+describe('getFloorData(floorNumber)', () => {
+  test('returns correct floor for floor 1', () => {
+    assert.equal(getFloorData(1), DUNGEON_FLOORS[0]);
+  });
+
+  test('returns correct floor for floor 5', () => {
+    assert.equal(getFloorData(5), DUNGEON_FLOORS[4]);
+  });
+
+  test('returns correct floor for floor 10', () => {
+    assert.equal(getFloorData(10), DUNGEON_FLOORS[9]);
+  });
+
+  test('returns null for floor 0', () => {
+    assert.equal(getFloorData(0), null);
+  });
+
+  test('returns null for floor 11', () => {
+    assert.equal(getFloorData(11), null);
+  });
+
+  test('returns null for negative floor numbers', () => {
+    assert.equal(getFloorData(-1), null);
+  });
+});
+
+describe('advanceFloor(state)', () => {
+  test('increments currentFloor by 1', () => {
+    const result = advanceFloor(makeState({ currentFloor: 1 }));
+    assert.equal(result.currentFloor, 2);
+  });
+
+  test('updates deepestFloor when going deeper', () => {
+    const result = advanceFloor(makeState({ currentFloor: 1, deepestFloor: 1 }));
+    assert.equal(result.deepestFloor, 2);
+  });
+
+  test('does not decrease deepestFloor', () => {
+    const result = advanceFloor(makeState({ currentFloor: 5, deepestFloor: 7 }));
+    assert.equal(result.deepestFloor, 7);
+  });
+
+  test('caps at floor 10', () => {
+    const result = advanceFloor(makeState({ currentFloor: 10, deepestFloor: 10 }));
+    assert.equal(result.currentFloor, 10);
+  });
+
+  test('resets stairsFound', () => {
+    const result = advanceFloor(makeState({ currentFloor: 2, stairsFound: true }));
+    assert.equal(result.stairsFound, false);
+  });
+
+  test('does not mutate input', () => {
+    const original = makeState({ currentFloor: 3, deepestFloor: 4, stairsFound: true });
+    const snapshot = clone(original);
+    advanceFloor(original);
+    assert.deepEqual(original, snapshot);
+  });
+});
+
+describe('clearFloor(state)', () => {
+  test('adds current floor to floorsCleared', () => {
+    const result = clearFloor(makeState({ currentFloor: 2 }));
+    assert.deepEqual(result.floorsCleared, [2]);
+  });
+
+  test('does not add duplicates', () => {
+    const result = clearFloor(
+      makeState({ currentFloor: 2, floorsCleared: [2] })
+    );
+    assert.deepEqual(result.floorsCleared, [2]);
+  });
+
+  test('returns unchanged copy if currentFloor is 0', () => {
+    const original = makeState({ currentFloor: 0, floorsCleared: [1] });
+    const result = clearFloor(original);
+    assert.deepEqual(result, original);
+    assert.notStrictEqual(result, original);
+  });
+
+  test('does not mutate input', () => {
+    const original = makeState({ currentFloor: 4, floorsCleared: [1, 2] });
+    const snapshot = clone(original);
+    clearFloor(original);
+    assert.deepEqual(original, snapshot);
+  });
+});
+
+describe('findStairs(state)', () => {
+  test('sets stairsFound to true', () => {
+    const result = findStairs(makeState());
+    assert.equal(result.stairsFound, true);
+  });
+
+  test('does not mutate input', () => {
+    const original = makeState({ stairsFound: false });
+    const snapshot = clone(original);
+    findStairs(original);
+    assert.deepEqual(original, snapshot);
+  });
+});
+
+describe('canAdvance(state)', () => {
+  test('returns false if stairsFound is false', () => {
+    const result = canAdvance(makeState({ currentFloor: 2, stairsFound: false }));
+    assert.equal(result, false);
+  });
+
+  test('returns false for invalid floor', () => {
+    const result = canAdvance(makeState({ currentFloor: 0, stairsFound: true }));
+    assert.equal(result, false);
+  });
+
+  test('returns true when stairs found and floor cleared (non-boss)', () => {
+    const result = canAdvance(
+      makeState({ currentFloor: 2, stairsFound: true, floorsCleared: [2] })
+    );
+    assert.equal(result, true);
+  });
+
+  test('returns true when stairs found on boss floor even if not cleared', () => {
+    const result = canAdvance(makeState({ currentFloor: 3, stairsFound: true }));
+    assert.equal(result, true);
+  });
+});
+
+describe('getScaledEnemy(enemy, floorNumber)', () => {
+  const baseEnemy = {
+    id: 'test',
+    hp: 10,
+    maxHp: 10,
+    atk: 5,
+    def: 4,
+    spd: 3,
+    xpReward: 7,
+    goldReward: 6,
+  };
+
+  test('returns same stats for floor 1 (multiplier 1.0)', () => {
+    const scaled = getScaledEnemy(baseEnemy, 1);
+    assert.deepEqual(scaled, baseEnemy);
+  });
+
+  test('returns higher stats for higher floors', () => {
+    const scaled = getScaledEnemy(baseEnemy, 2);
+    assert.ok(scaled.hp > baseEnemy.hp);
+    assert.ok(scaled.atk > baseEnemy.atk);
+  });
+
+  test('scales all relevant fields', () => {
+    const scaled = getScaledEnemy(baseEnemy, 5);
+    assert.ok(scaled.hp !== baseEnemy.hp);
+    assert.ok(scaled.maxHp !== baseEnemy.maxHp);
+    assert.ok(scaled.atk !== baseEnemy.atk);
+    assert.ok(scaled.def !== baseEnemy.def);
+    assert.ok(scaled.spd !== baseEnemy.spd);
+    assert.ok(scaled.xpReward !== baseEnemy.xpReward);
+    assert.ok(scaled.goldReward !== baseEnemy.goldReward);
+  });
+
+  test('returns copy of enemy if floor not found', () => {
+    const scaled = getScaledEnemy(baseEnemy, 0);
+    assert.deepEqual(scaled, baseEnemy);
+    assert.notStrictEqual(scaled, baseEnemy);
+  });
+
+  test('returns null if enemy is null', () => {
+    assert.equal(getScaledEnemy(null, 1), null);
+  });
+
+  test('does not mutate input enemy', () => {
+    const original = clone(baseEnemy);
+    const scaled = getScaledEnemy(baseEnemy, 2);
+    scaled.hp = 1;
+    assert.deepEqual(baseEnemy, original);
+  });
+});
+
+describe('getRandomEncounter(state, seed)', () => {
+  test('returns null when not in dungeon (currentFloor 0)', () => {
+    const result = getRandomEncounter(makeState({ currentFloor: 0 }), 1);
+    assert.equal(result, null);
+  });
+
+  test('returns null with seed 0', () => {
+    const result = getRandomEncounter(makeState({ currentFloor: 1 }), 0);
+    assert.equal(result, null);
+  });
+
+  test('returns null with undefined seed', () => {
+    const result = getRandomEncounter(makeState({ currentFloor: 1 }));
+    assert.equal(result, null);
+  });
+
+  test('returns object with enemyId and seed when encounter happens', () => {
+    const result = getRandomEncounter(makeState({ currentFloor: 1 }), 1);
+    assert.ok(result);
+    assert.equal(result.enemyId, 'slime');
+    assert.equal(result.seed, 16807);
+  });
+
+  test('enemyId is from current floor enemyPool', () => {
+    const result = getRandomEncounter(makeState({ currentFloor: 1 }), 1);
+    const pool = getFloorData(1).enemyPool;
+    assert.ok(pool.includes(result.enemyId));
+  });
+
+  test('deterministic - same seed gives same result', () => {
+    const first = getRandomEncounter(makeState({ currentFloor: 1 }), 1);
+    const second = getRandomEncounter(makeState({ currentFloor: 1 }), 1);
+    assert.deepEqual(first, second);
+  });
+
+  test('sometimes returns null based on encounter rate', () => {
+    const seed = 50000;
+    const roll = getRoll(seed);
+    assert.ok(roll > getFloorData(1).encounterRate);
+    const result = getRandomEncounter(makeState({ currentFloor: 1 }), seed);
+    assert.equal(result, null);
+  });
+});
+
+describe('getDungeonProgress(state)', () => {
+  test('returns correct structure', () => {
+    const progress = getDungeonProgress(makeState());
+    assert.deepEqual(Object.keys(progress).sort(), [
+      'currentFloor',
+      'deepestFloor',
+      'floorsCleared',
+      'percentComplete',
+      'totalFloors',
+    ]);
+  });
+
+  test('percentComplete is 0 when no floors cleared', () => {
+    const progress = getDungeonProgress(makeState());
+    assert.equal(progress.percentComplete, 0);
+  });
+
+  test('percentComplete is 100 when all floors cleared', () => {
+    const progress = getDungeonProgress(
+      makeState({ floorsCleared: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] })
+    );
+    assert.equal(progress.percentComplete, 100);
+  });
+
+  test('totalFloors is 10', () => {
+    const progress = getDungeonProgress(makeState());
+    assert.equal(progress.totalFloors, 10);
+  });
+});
+
+describe('isFloorCleared(state, floorNumber)', () => {
+  test('returns true for cleared floors', () => {
+    const result = isFloorCleared(makeState({ floorsCleared: [2] }), 2);
+    assert.equal(result, true);
+  });
+
+  test('returns false for uncleared floors', () => {
+    const result = isFloorCleared(makeState({ floorsCleared: [2] }), 3);
+    assert.equal(result, false);
+  });
+});
+
+describe('getFloorTheme(floorNumber)', () => {
+  test('returns correct theme for floor 1', () => {
+    assert.equal(getFloorTheme(1), 'cavern');
+  });
+
+  test('returns correct theme for floor 3', () => {
+    assert.equal(getFloorTheme(3), 'goblin_stronghold');
+  });
+
+  test('returns correct theme for floor 10', () => {
+    assert.equal(getFloorTheme(10), 'abyss');
+  });
+
+  test('returns null for invalid floor', () => {
+    assert.equal(getFloorTheme(0), null);
+  });
+});
+
+describe('canEnterDungeon(playerLevel)', () => {
+  test('returns false for level 1', () => {
+    assert.equal(canEnterDungeon(1), false);
+  });
+
+  test('returns false for level 2', () => {
+    assert.equal(canEnterDungeon(2), false);
+  });
+
+  test('returns true for level 3 and above', () => {
+    assert.equal(canEnterDungeon(3), true);
+  });
+});
+
+describe('getBossForFloor(floorNumber)', () => {
+  test('returns bossId for floor 3', () => {
+    assert.equal(getBossForFloor(3), 'goblin_chief');
+  });
+
+  test('returns bossId for floor 10', () => {
+    assert.equal(getBossForFloor(10), 'abyss_overlord');
+  });
+
+  test('returns null for non-boss floors', () => {
+    assert.equal(getBossForFloor(2), null);
+  });
+
+  test('returns null for invalid floor number', () => {
+    assert.equal(getBossForFloor(0), null);
+  });
+});


### PR DESCRIPTION
## Dungeon Floor Progression System

Adds a complete 10-floor dungeon progression system that gives the game depth and replayability.

### Features
- **10 themed dungeon floors** from Echoing Grotto (floor 1) to Abyssal Throne (floor 10)
- **Floor themes:** cavern, goblin_stronghold, crypt, frozen_depths, ruins, inferno, abyss
- **Enemy pools per floor** drawn from existing enemy roster (no new enemies needed)
- **Difficulty scaling:** 1.0x to 2.35x stat multiplier across floors
- **Boss floors** at levels 3, 6, 9, and 10
- **Encounter rate scaling:** 0.30 to 0.65 across floors
- **Park-Miller LCG** for deterministic random encounters
- **Minimum level requirements** per floor (level 3+ to enter dungeon)

### New Files
- `src/dungeon-floors.js` (283 lines, 16 exported functions)
- `tests/dungeon-floors-test.mjs` (73 tests, all passing)

### Exported Functions
`DUNGEON_FLOORS`, `createDungeonState`, `enterDungeon`, `exitDungeon`, `getFloorData`, `advanceFloor`, `clearFloor`, `findStairs`, `canAdvance`, `getScaledEnemy`, `getRandomEncounter`, `getDungeonProgress`, `isFloorCleared`, `getFloorTheme`, `canEnterDungeon`, `getBossForFloor`

### Design
- Pure functions, immutable state (spread operators for all updates)
- No external imports - standalone data/logic module
- All enemy IDs reference existing enemies.js roster
- Full test suite still green

### Floor Overview
| Floor | Name | Theme | Boss | Difficulty |
|-------|------|-------|------|-----------|
| 1 | Echoing Grotto | cavern | - | 1.0x |
| 2 | Crystal Hollows | cavern | - | 1.15x |
| 3 | Goblin Stronghold | goblin_stronghold | goblin_chief | 1.3x |
| 4 | Silent Catacombs | crypt | - | 1.45x |
| 5 | Shattered Mausoleum | crypt | - | 1.6x |
| 6 | Frozen Depths | frozen_depths | ice-spirit | 1.75x |
| 7 | Ruined Causeway | ruins | - | 1.9x |
| 8 | Forgotten Bastion | ruins | - | 2.05x |
| 9 | Infernal Gate | inferno | dragon | 2.2x |
| 10 | Abyssal Throne | abyss | abyss_overlord | 2.35x |