### PR TITLE
feat: add dungeon UI integration (handler, UI, render wiring, 29 tests)

### DIFF
--- a/src/dungeon-ui.js
+++ b/src/dungeon-ui.js
@@ -1,0 +1,139 @@
+import { getFloorData, getDungeonProgress, canAdvance, canEnterDungeon, getBossForFloor, isFloorCleared, DUNGEON_FLOORS } from './dungeon-floors.js';
+
+const THEME_COLORS = {
+  cavern: '#8B7355',
+  goblin_stronghold: '#556B2F',
+  crypt: '#4A4A6A',
+  frozen_depths: '#87CEEB',
+  ruins: '#8B8682',
+  inferno: '#CD3700',
+  abyss: '#2F0A28',
+};
+
+const THEME_ICONS = {
+  cavern: '🪨',
+  goblin_stronghold: '⚔️',
+  crypt: '💀',
+  frozen_depths: '❄️',
+  ruins: '🏚️',
+  inferno: '🔥',
+  abyss: '🌀',
+};
+
+export function renderDungeonPanel(state) {
+  const ds = state.dungeonState;
+  if (!ds || !ds.inDungeon) return '';
+
+  const floor = getFloorData(ds.currentFloor);
+  if (!floor) return '<div class="card">Error: Invalid dungeon floor.</div>';
+
+  const progress = getDungeonProgress(ds);
+  const theme = floor.theme || 'cavern';
+  const themeColor = THEME_COLORS[theme] || '#8B7355';
+  const themeIcon = THEME_ICONS[theme] || '🗺️';
+  const cleared = isFloorCleared(ds, ds.currentFloor);
+  const bossId = getBossForFloor(ds.currentFloor);
+  const canGo = canAdvance(ds);
+
+  const progressBar = `<div class="dungeon-progress-bar">
+    <div class="dungeon-progress-fill" style="width:${progress.percentComplete}%;background:${themeColor}"></div>
+  </div>`;
+
+  const floorListHtml = DUNGEON_FLOORS.map(f => {
+    const isCurrent = f.id === ds.currentFloor;
+    const isCleared = ds.floorsCleared.includes(f.id);
+    const icon = isCleared ? '✅' : (isCurrent ? '👉' : (f.id <= ds.deepestFloor ? '⬜' : '🔒'));
+    return `<span class="dungeon-floor-marker${isCurrent ? ' current' : ''}${isCleared ? ' cleared' : ''}" title="Floor ${f.id}: ${f.name}">${icon}</span>`;
+  }).join('');
+
+  return `
+    <div class="card dungeon-panel" style="border-left:4px solid ${themeColor}">
+      <h2>${themeIcon} ${floor.name} — Floor ${floor.id}</h2>
+      <p class="dungeon-desc">${floor.description}</p>
+      <div class="kv">
+        <div>Theme</div><div><b>${theme.replace(/_/g, ' ')}</b></div>
+        <div>Difficulty</div><div><b>${floor.difficultyMultiplier}x</b></div>
+        <div>Encounter Rate</div><div><b>${Math.round(floor.encounterRate * 100)}%</b></div>
+        <div>Stairs Found</div><div><b>${ds.stairsFound ? '✅ Yes' : '❌ No'}</b></div>
+        <div>Floor Cleared</div><div><b>${cleared ? '✅ Yes' : '❌ No'}</b></div>
+        ${floor.bossFloor ? `<div>Boss</div><div><b>${bossId || 'Unknown'} ${cleared ? '(Defeated)' : '(Alive)'}</b></div>` : ''}
+      </div>
+      <div class="dungeon-floor-list">${floorListHtml}</div>
+      ${progressBar}
+      <div class="dungeon-progress-text">${progress.floorsCleared}/${progress.totalFloors} floors cleared (${progress.percentComplete}%)</div>
+    </div>
+  `;
+}
+
+export function renderDungeonActions(state) {
+  const ds = state.dungeonState;
+  if (!ds || !ds.inDungeon) return '';
+
+  const floor = getFloorData(ds.currentFloor);
+  const canGo = canAdvance(ds);
+  const isBossFloor = floor?.bossFloor || false;
+  const bossDefeated = isFloorCleared(ds, ds.currentFloor);
+  const isLastFloor = ds.currentFloor >= 10;
+
+  let buttons = `<button id="btnDungeonSearch">Search Floor 🔍</button>`;
+
+  if (isBossFloor && !bossDefeated) {
+    buttons += `<button id="btnDungeonBoss" class="boss-btn">Fight Boss ⚔️</button>`;
+  }
+
+  if (canGo && !isLastFloor) {
+    buttons += `<button id="btnDungeonAdvance">Descend ⬇️</button>`;
+  }
+
+  buttons += `<button id="btnDungeonInventory">Inventory 🎒</button>`;
+  buttons += `<button id="btnDungeonExit">Exit Dungeon 🚪</button>`;
+
+  return `<div class="buttons">${buttons}</div>`;
+}
+
+export function attachDungeonHandlers(dispatch) {
+  const search = document.getElementById('btnDungeonSearch');
+  if (search) search.onclick = () => dispatch({ type: 'DUNGEON_SEARCH' });
+
+  const boss = document.getElementById('btnDungeonBoss');
+  if (boss) boss.onclick = () => dispatch({ type: 'DUNGEON_FIGHT_BOSS' });
+
+  const advance = document.getElementById('btnDungeonAdvance');
+  if (advance) advance.onclick = () => dispatch({ type: 'DUNGEON_ADVANCE' });
+
+  const inv = document.getElementById('btnDungeonInventory');
+  if (inv) inv.onclick = () => dispatch({ type: 'VIEW_INVENTORY' });
+
+  const exit = document.getElementById('btnDungeonExit');
+  if (exit) exit.onclick = () => dispatch({ type: 'DUNGEON_EXIT' });
+}
+
+export function getDungeonStyles() {
+  return `
+    .dungeon-panel { position: relative; }
+    .dungeon-desc { font-style: italic; color: #aaa; margin: 4px 0 8px; }
+    .dungeon-floor-list { display: flex; gap: 4px; margin: 8px 0; flex-wrap: wrap; }
+    .dungeon-floor-marker { font-size: 1.1em; cursor: default; }
+    .dungeon-floor-marker.current { font-weight: bold; }
+    .dungeon-progress-bar { width: 100%; height: 8px; background: #333; border-radius: 4px; margin: 6px 0 2px; overflow: hidden; }
+    .dungeon-progress-fill { height: 100%; border-radius: 4px; transition: width 0.3s ease; }
+    .dungeon-progress-text { font-size: 0.85em; color: #aaa; text-align: center; }
+    .boss-btn { background: #8B0000 !important; border-color: #CD3700 !important; }
+    .boss-btn:hover { background: #CD3700 !important; }
+    .dungeon-enter-btn { background: #2F4F4F !important; border-color: #5F9EA0 !important; margin-top: 4px; }
+    .dungeon-enter-btn:hover { background: #5F9EA0 !important; }
+  `;
+}
+
+export function shouldShowDungeonEntrance(state) {
+  if (state.phase !== 'exploration') return false;
+  if (!state.player || !canEnterDungeon(state.player.level)) return false;
+  const roomId = getRoomIdFromWorld(state.world);
+  return roomId === 'sw';
+}
+
+function getRoomIdFromWorld(world) {
+  if (!world) return null;
+  const ROOM_ID_MAP = [['nw', 'n', 'ne'], ['w', 'center', 'e'], ['sw', 's', 'se']];
+  return ROOM_ID_MAP[world.roomRow]?.[world.roomCol] ?? null;
+}

--- a/src/handlers/dungeon-handler.js
+++ b/src/handlers/dungeon-handler.js
@@ -1,0 +1,237 @@
+import {
+  createDungeonState,
+  enterDungeon,
+  exitDungeon,
+  getFloorData,
+  advanceFloor,
+  clearFloor,
+  findStairs,
+  canAdvance,
+  getScaledEnemy,
+  canEnterDungeon,
+  getBossForFloor,
+  getDungeonProgress,
+  DUNGEON_FLOORS,
+} from '../dungeon-floors.js';
+import { ENEMIES } from '../data/enemies.js';
+import { pushLog } from '../state.js';
+import { nextRng } from '../combat.js';
+
+export function handleDungeonAction(state, action) {
+  if (!action || !action.type) {
+    return null;
+  }
+
+  if (action.type === 'ENTER_DUNGEON') {
+    if (state.phase !== 'exploration') {
+      return null;
+    }
+
+    if (!canEnterDungeon(state.player.level)) {
+      return pushLog(state, 'You must be at least level 3 to enter the dungeon.');
+    }
+
+    const dungeonState = enterDungeon(state.dungeonState || createDungeonState());
+
+    return pushLog(
+      {
+        ...state,
+        dungeonState,
+        phase: 'dungeon',
+      },
+      'You descend into the dungeon...'
+    );
+  }
+
+  if (action.type === 'DUNGEON_SEARCH') {
+    if (state.phase !== 'dungeon' || !state.dungeonState?.inDungeon) {
+      return null;
+    }
+
+    const floorData = getFloorData(state.dungeonState.currentFloor);
+    if (!floorData) {
+      return pushLog(state, 'Something is wrong with this floor.');
+    }
+
+    const rng = nextRng(state.rngSeed || Date.now());
+    const next = { ...state, rngSeed: rng.seed };
+    const roll = rng.value;
+
+    if (roll < floorData.encounterRate) {
+      const poolIndex = Math.floor((rng.value * 1000) % floorData.enemyPool.length);
+      const enemyId = floorData.enemyPool[poolIndex];
+      const enemyBase = ENEMIES[enemyId];
+      if (!enemyBase) {
+        return pushLog(next, 'You search but find nothing unusual.');
+      }
+
+      const scaled = getScaledEnemy(enemyBase, state.dungeonState.currentFloor);
+      const enemy = {
+        ...scaled,
+        hp: scaled.maxHp,
+        defending: false,
+        statusEffects: [],
+      };
+
+      return pushLog(
+        pushLog(
+          {
+            ...next,
+            enemy,
+            phase: 'player-turn',
+            turn: 1,
+            player: {
+              ...next.player,
+              defending: false,
+              statusEffects: [],
+            },
+            inDungeonCombat: true,
+          },
+          'You search the floor...'
+        ),
+        `A ${enemy.name} attacks! (Floor ${state.dungeonState.currentFloor})`
+      );
+    }
+
+    if (roll < floorData.encounterRate + 0.25 && !state.dungeonState.stairsFound) {
+      const dungeonState = findStairs(state.dungeonState);
+      return pushLog(
+        {
+          ...next,
+          dungeonState,
+        },
+        'You discover a stairway leading deeper!'
+      );
+    }
+
+    return pushLog(next, 'You search the area but find nothing of interest.');
+  }
+
+  if (action.type === 'DUNGEON_ADVANCE') {
+    if (state.phase !== 'dungeon' || !state.dungeonState?.inDungeon) {
+      return null;
+    }
+
+    if (!canAdvance(state.dungeonState)) {
+      if (!state.dungeonState.stairsFound) {
+        return pushLog(state, 'You need to find the stairs before advancing.');
+      }
+
+      return pushLog(state, 'You cannot advance right now.');
+    }
+
+    if (state.dungeonState.currentFloor >= 10) {
+      return pushLog(state, 'You have reached the deepest floor. There is nowhere deeper to go.');
+    }
+
+    const dungeonState = advanceFloor(state.dungeonState);
+    const floorData = getFloorData(dungeonState.currentFloor);
+
+    if (!floorData) {
+      return pushLog({
+        ...state,
+        dungeonState,
+      }, 'You descend, but the path feels unstable.');
+    }
+
+    return pushLog(
+      {
+        ...state,
+        dungeonState,
+      },
+      `You descend to floor ${dungeonState.currentFloor}.`
+    );
+  }
+
+  if (action.type === 'DUNGEON_FIGHT_BOSS') {
+    if (state.phase !== 'dungeon' || !state.dungeonState?.inDungeon) {
+      return null;
+    }
+
+    const floorData = getFloorData(state.dungeonState.currentFloor);
+    if (!floorData || !floorData.bossFloor) {
+      return pushLog(state, 'There is no boss on this floor.');
+    }
+
+    if (state.dungeonState.floorsCleared?.includes(state.dungeonState.currentFloor)) {
+      return pushLog(state, 'You have already defeated the boss of this floor.');
+    }
+
+    const bossId = getBossForFloor(state.dungeonState.currentFloor);
+    const enemyBase = ENEMIES[bossId];
+    if (!enemyBase) {
+      return pushLog(state, 'The boss cannot be found.');
+    }
+
+    const scaled = getScaledEnemy(enemyBase, state.dungeonState.currentFloor);
+    const enemy = {
+      ...scaled,
+      hp: scaled.maxHp,
+      defending: false,
+      statusEffects: [],
+    };
+
+    return pushLog(
+      pushLog(
+        {
+          ...state,
+          enemy,
+          phase: 'player-turn',
+          turn: 1,
+          player: {
+            ...state.player,
+            defending: false,
+            statusEffects: [],
+          },
+          inDungeonCombat: true,
+          dungeonBossFight: true,
+        },
+        'You challenge the floor boss!'
+      ),
+      `A mighty ${enemy.name} appears!`
+    );
+  }
+
+  if (action.type === 'DUNGEON_EXIT') {
+    if (state.phase !== 'dungeon') {
+      return null;
+    }
+
+    const dungeonState = exitDungeon(state.dungeonState || createDungeonState());
+
+    const { inDungeonCombat, ...rest } = state;
+
+    return pushLog(
+      {
+        ...rest,
+        dungeonState,
+        phase: 'exploration',
+      },
+      'You leave the dungeon and return to the surface.'
+    );
+  }
+
+  if (action.type === 'DUNGEON_RETURN') {
+    if (!state.inDungeonCombat) {
+      return null;
+    }
+
+    let dungeonState = state.dungeonState;
+    if (state.dungeonBossFight && dungeonState) {
+      dungeonState = clearFloor(dungeonState);
+    }
+
+    const { inDungeonCombat, dungeonBossFight, ...rest } = state;
+
+    return pushLog(
+      {
+        ...rest,
+        dungeonState,
+        phase: 'dungeon',
+      },
+      'You continue exploring the dungeon.'
+    );
+  }
+
+  return null;
+}

--- a/src/handlers/ui-handler.js
+++ b/src/handlers/ui-handler.js
@@ -16,6 +16,7 @@ import { createCraftingState, craftItem } from '../crafting.js';
 import { createTalentState, allocateTalent, deallocateTalent, resetAllTalents } from '../talents.js';
 import { recruitCompanion, dismissCompanion } from '../companions.js';
 import { shouldShowSpecialization, createSpecializationState, applySpecialization } from '../specialization-ui.js';
+import { clearFloor as clearDungeonFloor } from '../dungeon-floors.js';
 
 function getRoomDescription(worldState) {
   const room = getCurrentRoom(worldState);
@@ -190,13 +191,35 @@ export function handleUIAction(state, action) {
       return next;
     }
 
-    // Return to exploration
-    const exits = getRoomExits(state.world);
+    // Track battle stats
     let gs = state.gameStats || createGameStats();
     gs = recordBattleWon(gs);
     if (state.enemy?.name) gs = recordEnemyDefeated(gs, state.enemy.name);
     if ((state.xpGained ?? 0) > 0) gs = recordXPEarned(gs, state.xpGained);
     if ((state.goldGained ?? 0) > 0) gs = recordGoldEarned(gs, state.goldGained);
+
+    // Return to dungeon if in dungeon combat
+    if (state.inDungeonCombat && state.dungeonState?.inDungeon) {
+      let dungeonState = state.dungeonState;
+      if (state.dungeonBossFight) {
+        dungeonState = clearDungeonFloor(dungeonState);
+      }
+      const { inDungeonCombat, dungeonBossFight, ...rest } = state;
+      let next = {
+        ...rest,
+        dungeonState,
+        phase: 'dungeon',
+        player: { ...state.player, defending: false },
+        battleSummary: undefined,
+        pendingLevelUps: undefined,
+        gameStats: gs,
+      };
+      next = pushLog(next, 'You continue exploring the dungeon.');
+      return next;
+    }
+
+    // Return to exploration
+    const exits = getRoomExits(state.world);
     
     let next = {
       ...state,

--- a/src/main.js
+++ b/src/main.js
@@ -4,6 +4,7 @@ import { handleCombatAction, handleEnemyTurnLogic } from './handlers/combat-hand
 import { handleExplorationAction } from './handlers/exploration-handler.js';
 import { handleSystemAction } from './handlers/system-handler.js';
 import { handleUIAction } from './handlers/ui-handler.js';
+import { handleDungeonAction } from './handlers/dungeon-handler.js';
 import { handleStateTransitions } from './state-transitions.js';
 import { initAudio } from './audio-system.js';
 
@@ -47,6 +48,7 @@ function setState(next) {
 function dispatch(action) {
   // Try each handler in order
   const next = handleCombatAction(state, action) ||
+               handleDungeonAction(state, action) ||
                handleExplorationAction(state, action) ||
                handleSystemAction(state, action) ||
                handleUIAction(state, action);

--- a/src/render.js
+++ b/src/render.js
@@ -27,6 +27,7 @@ import { hasShop } from './shop.js';
 import { renderBestiaryPanel } from './bestiary-ui.js';
 import { renderJournalPanel, renderJournalBadge } from './journal-ui.js';
 import { renderCompanionPanel, renderCompanionHUD, renderCompanionBadge } from './companions-ui.js';
+import { renderDungeonPanel, renderDungeonActions, attachDungeonHandlers, getDungeonStyles, shouldShowDungeonEntrance } from './dungeon-ui.js';
 
 function hpLine(entity) {
   const pct = Math.round((entity.hp / entity.maxHp) * 100);
@@ -246,6 +247,7 @@ export function render(state, dispatch) {
         <button id="btnWest">West</button>
         <button id="btnEast">East</button>
         <button id="btnSeek">Seek Battle</button>
+        ${shouldShowDungeonEntrance(state) ? '<button id="btnEnterDungeon" class="dungeon-enter-btn">Enter Dungeon \u26CF\uFE0F</button>' : ''}
         <button id="btnInventory">Inventory</button>
         <button id="btnQuests">Quests 📜</button>
         <button id="btnViewStats">Stats 📊</button>
@@ -265,6 +267,8 @@ export function render(state, dispatch) {
     document.getElementById('btnWest').onclick = () => dispatch({ type: 'EXPLORE', direction: 'west' });
     document.getElementById('btnEast').onclick = () => dispatch({ type: 'EXPLORE', direction: 'east' });
     document.getElementById('btnSeek').onclick = () => dispatch({ type: 'SEEK_ENCOUNTER' });
+    const dungeonBtn = document.getElementById('btnEnterDungeon');
+    if (dungeonBtn) dungeonBtn.onclick = () => dispatch({ type: 'ENTER_DUNGEON' });
     document.getElementById('btnInventory').onclick = () => dispatch({ type: 'VIEW_INVENTORY' });
     document.getElementById('btnQuests').onclick = () => dispatch({ type: 'VIEW_QUESTS' });
     document.getElementById('btnViewStats').onclick = () => dispatch({ type: 'VIEW_STATS' });
@@ -1157,6 +1161,29 @@ if (state.phase === 'achievements') {
     // Also wire data-action close button from bestiary-ui
     const dataCloseBtn = hud.querySelector('[data-action="close-bestiary"]');
     if (dataCloseBtn) dataCloseBtn.onclick = () => dispatch({ type: 'CLOSE_BESTIARY' });
+    log.innerHTML = state.log.slice().reverse().map(line => '<div class="logLine">' + esc(line) + '</div>').join('');
+    finalizeRender();
+    return;
+  }
+
+  if (state.phase === 'dungeon') {
+    const dungeonHtml = renderDungeonPanel(state);
+    hud.innerHTML = `
+      <div class="row">
+        <div class="card">
+          <h2>${esc(state.player.name)}</h2>
+          <div class="kv">
+            <div>Class</div><div><b>${esc(state.player.classId ? state.player.classId[0].toUpperCase() + state.player.classId.slice(1) : 'Adventurer')}</b></div>
+            <div>HP</div><div><b>${hpLine(state.player)}</b></div>
+            <div>MP</div><div><b>${state.player.mp ?? 0} / ${state.player.maxMp ?? 0}</b></div>
+            <div>Level</div><div><b>${state.player.level ?? 1}</b></div>
+          </div>
+        </div>
+        ${dungeonHtml}
+      </div>
+    `;
+    actions.innerHTML = renderDungeonActions(state);
+    attachDungeonHandlers(dispatch);
     log.innerHTML = state.log.slice().reverse().map(line => '<div class="logLine">' + esc(line) + '</div>').join('');
     finalizeRender();
     return;

--- a/tests/dungeon-handler-test.mjs
+++ b/tests/dungeon-handler-test.mjs
@@ -1,0 +1,335 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+// Import the handler
+import { handleDungeonAction } from '../src/handlers/dungeon-handler.js';
+
+// Import dungeon-floors for state creation
+import { createDungeonState, enterDungeon, findStairs, clearFloor } from '../src/dungeon-floors.js';
+
+function makeState(overrides = {}) {
+  return {
+    phase: 'exploration',
+    log: [],
+    rngSeed: 200000,
+    player: {
+      name: 'TestHero',
+      classId: 'warrior',
+      level: 5,
+      hp: 50,
+      maxHp: 50,
+      mp: 10,
+      maxMp: 10,
+      atk: 12,
+      def: 10,
+      spd: 8,
+      xp: 100,
+      gold: 50,
+      inventory: {},
+      defending: false,
+      statusEffects: [],
+    },
+    world: { roomRow: 2, roomCol: 0 }, // SW room
+    ...overrides,
+  };
+}
+
+function makeDungeonState(overrides = {}) {
+  return {
+    ...makeState({ phase: 'dungeon' }),
+    dungeonState: enterDungeon(createDungeonState()),
+    ...overrides,
+  };
+}
+
+describe('Dungeon Handler', () => {
+  // === ENTER_DUNGEON ===
+  describe('ENTER_DUNGEON', () => {
+    it('should enter dungeon from exploration', () => {
+      const state = makeState();
+      const result = handleDungeonAction(state, { type: 'ENTER_DUNGEON' });
+      assert.ok(result, 'should return a state');
+      assert.equal(result.phase, 'dungeon');
+      assert.equal(result.dungeonState.inDungeon, true);
+      assert.equal(result.dungeonState.currentFloor, 1);
+    });
+
+    it('should reject if not in exploration phase', () => {
+      const state = makeState({ phase: 'combat' });
+      const result = handleDungeonAction(state, { type: 'ENTER_DUNGEON' });
+      assert.equal(result, null);
+    });
+
+    it('should reject if player level too low', () => {
+      const state = makeState({ player: { ...makeState().player, level: 2 } });
+      const result = handleDungeonAction(state, { type: 'ENTER_DUNGEON' });
+      assert.ok(result);
+      assert.equal(result.phase, 'exploration'); // stays in exploration
+      assert.ok(result.log.some(l => l.includes('level 3')));
+    });
+
+    it('should preserve existing dungeon progress', () => {
+      const ds = createDungeonState();
+      ds.deepestFloor = 5;
+      ds.floorsCleared = [1, 2, 3];
+      const state = makeState({ dungeonState: ds });
+      const result = handleDungeonAction(state, { type: 'ENTER_DUNGEON' });
+      assert.ok(result);
+      assert.equal(result.dungeonState.deepestFloor, 5);
+      assert.deepEqual(result.dungeonState.floorsCleared, [1, 2, 3]);
+    });
+
+    it('should add log message about descending', () => {
+      const state = makeState();
+      const result = handleDungeonAction(state, { type: 'ENTER_DUNGEON' });
+      assert.ok(result.log.some(l => l.includes('descend')));
+    });
+  });
+
+  // === DUNGEON_SEARCH ===
+  describe('DUNGEON_SEARCH', () => {
+    it('should return null if not in dungeon phase', () => {
+      const state = makeState();
+      const result = handleDungeonAction(state, { type: 'DUNGEON_SEARCH' });
+      assert.equal(result, null);
+    });
+
+    it('should return null if dungeonState not in dungeon', () => {
+      const state = makeState({ phase: 'dungeon', dungeonState: createDungeonState() });
+      const result = handleDungeonAction(state, { type: 'DUNGEON_SEARCH' });
+      assert.equal(result, null);
+    });
+
+    it('should produce a result when in dungeon', () => {
+      const state = makeDungeonState();
+      const result = handleDungeonAction(state, { type: 'DUNGEON_SEARCH' });
+      assert.ok(result, 'should return a state');
+      // Result could be encounter, stairs found, or nothing
+      assert.ok(result.log.length > 0);
+    });
+
+    it('should update rngSeed', () => {
+      const state = makeDungeonState({ rngSeed: 300000 });
+      const result = handleDungeonAction(state, { type: 'DUNGEON_SEARCH' });
+      assert.ok(result);
+      assert.notEqual(result.rngSeed, 300000);
+    });
+
+    it('should trigger combat with encounter seed', () => {
+      // Use a seed that gives a low roll (< encounterRate 0.3)
+      // Park-Miller: next = (seed * 16807) % 2147483647
+      // Need to find seed where nextSeed / 2147483647 < 0.3
+      let testSeed = 100001;
+      let found = false;
+      for (let i = 100001; i < 200000; i++) {
+        const next = (i * 16807) % 2147483647;
+        const val = next / 2147483647;
+        if (val < 0.3) {
+          testSeed = i;
+          found = true;
+          break;
+        }
+      }
+      if (found) {
+        const state = makeDungeonState({ rngSeed: testSeed });
+        const result = handleDungeonAction(state, { type: 'DUNGEON_SEARCH' });
+        assert.ok(result);
+        if (result.phase === 'player-turn') {
+          assert.ok(result.enemy, 'should have enemy in combat');
+          assert.ok(result.inDungeonCombat, 'should mark as dungeon combat');
+          assert.equal(result.turn, 1);
+        }
+      }
+    });
+
+    it('should find stairs with appropriate seed', () => {
+      // Need roll >= encounterRate but < encounterRate + 0.25, and stairs not found
+      let testSeed = 100001;
+      let found = false;
+      for (let i = 100001; i < 500000; i++) {
+        const next = (i * 16807) % 2147483647;
+        const val = next / 2147483647;
+        if (val >= 0.3 && val < 0.55) {
+          testSeed = i;
+          found = true;
+          break;
+        }
+      }
+      if (found) {
+        const state = makeDungeonState({ rngSeed: testSeed });
+        const result = handleDungeonAction(state, { type: 'DUNGEON_SEARCH' });
+        assert.ok(result);
+        if (result.dungeonState?.stairsFound) {
+          assert.ok(result.log.some(l => l.includes('stairway')));
+        }
+      }
+    });
+  });
+
+  // === DUNGEON_ADVANCE ===
+  describe('DUNGEON_ADVANCE', () => {
+    it('should return null if not in dungeon', () => {
+      const result = handleDungeonAction(makeState(), { type: 'DUNGEON_ADVANCE' });
+      assert.equal(result, null);
+    });
+
+    it('should reject if stairs not found', () => {
+      const state = makeDungeonState();
+      const result = handleDungeonAction(state, { type: 'DUNGEON_ADVANCE' });
+      assert.ok(result);
+      assert.equal(result.phase, 'dungeon');
+      assert.ok(result.log.some(l => l.includes('stairs')));
+    });
+
+    it('should advance floor when canAdvance is true', () => {
+      const ds = enterDungeon(createDungeonState());
+      const withStairs = findStairs(ds);
+      const cleared = clearFloor(withStairs);
+      const state = makeDungeonState({ dungeonState: cleared });
+      const result = handleDungeonAction(state, { type: 'DUNGEON_ADVANCE' });
+      assert.ok(result);
+      assert.equal(result.dungeonState.currentFloor, 2);
+      assert.ok(result.log.some(l => l.includes('floor 2') || l.includes('Floor 2')));
+    });
+
+    it('should reject at floor 10', () => {
+      const ds = {
+        currentFloor: 10,
+        deepestFloor: 10,
+        floorsCleared: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
+        inDungeon: true,
+        stairsFound: true,
+      };
+      const state = makeDungeonState({ dungeonState: ds });
+      const result = handleDungeonAction(state, { type: 'DUNGEON_ADVANCE' });
+      assert.ok(result);
+      assert.ok(result.log.some(l => l.includes('deepest')));
+    });
+
+    it('should reset stairsFound after advancing', () => {
+      const ds = { ...enterDungeon(createDungeonState()), stairsFound: true, floorsCleared: [1] };
+      const state = makeDungeonState({ dungeonState: ds });
+      const result = handleDungeonAction(state, { type: 'DUNGEON_ADVANCE' });
+      assert.ok(result);
+      assert.equal(result.dungeonState.stairsFound, false);
+    });
+  });
+
+  // === DUNGEON_FIGHT_BOSS ===
+  describe('DUNGEON_FIGHT_BOSS', () => {
+    it('should return null if not in dungeon', () => {
+      const result = handleDungeonAction(makeState(), { type: 'DUNGEON_FIGHT_BOSS' });
+      assert.equal(result, null);
+    });
+
+    it('should reject on non-boss floor', () => {
+      // Floor 1 is not a boss floor
+      const state = makeDungeonState();
+      const result = handleDungeonAction(state, { type: 'DUNGEON_FIGHT_BOSS' });
+      assert.ok(result);
+      assert.ok(result.log.some(l => l.includes('no boss')));
+    });
+
+    it('should start boss fight on boss floor', () => {
+      // Floor 3 is a boss floor (goblin_chief)
+      const ds = { ...enterDungeon(createDungeonState()), currentFloor: 3 };
+      const state = makeDungeonState({ dungeonState: ds, player: { ...makeDungeonState().player, level: 5 } });
+      const result = handleDungeonAction(state, { type: 'DUNGEON_FIGHT_BOSS' });
+      assert.ok(result);
+      assert.equal(result.phase, 'player-turn');
+      assert.ok(result.enemy);
+      assert.ok(result.inDungeonCombat);
+      assert.ok(result.dungeonBossFight);
+      assert.ok(result.log.some(l => l.includes('boss')));
+    });
+
+    it('should reject if boss already defeated', () => {
+      const ds = { ...enterDungeon(createDungeonState()), currentFloor: 3, floorsCleared: [3] };
+      const state = makeDungeonState({ dungeonState: ds });
+      const result = handleDungeonAction(state, { type: 'DUNGEON_FIGHT_BOSS' });
+      assert.ok(result);
+      assert.ok(result.log.some(l => l.includes('already defeated')));
+    });
+  });
+
+  // === DUNGEON_EXIT ===
+  describe('DUNGEON_EXIT', () => {
+    it('should exit dungeon', () => {
+      const state = makeDungeonState();
+      const result = handleDungeonAction(state, { type: 'DUNGEON_EXIT' });
+      assert.ok(result);
+      assert.equal(result.phase, 'exploration');
+      assert.equal(result.dungeonState.inDungeon, false);
+      assert.ok(result.log.some(l => l.includes('leave') || l.includes('return')));
+    });
+
+    it('should return null if not in dungeon phase', () => {
+      const result = handleDungeonAction(makeState(), { type: 'DUNGEON_EXIT' });
+      assert.equal(result, null);
+    });
+
+    it('should preserve dungeon progress on exit', () => {
+      const ds = { ...enterDungeon(createDungeonState()), deepestFloor: 4, floorsCleared: [1, 2, 3] };
+      const state = makeDungeonState({ dungeonState: ds });
+      const result = handleDungeonAction(state, { type: 'DUNGEON_EXIT' });
+      assert.ok(result);
+      assert.equal(result.dungeonState.deepestFloor, 4);
+      assert.deepEqual(result.dungeonState.floorsCleared, [1, 2, 3]);
+    });
+  });
+
+  // === DUNGEON_RETURN ===
+  describe('DUNGEON_RETURN', () => {
+    it('should return to dungeon from combat', () => {
+      const ds = enterDungeon(createDungeonState());
+      const state = {
+        ...makeDungeonState({ dungeonState: ds }),
+        phase: 'battle-summary',
+        inDungeonCombat: true,
+      };
+      const result = handleDungeonAction(state, { type: 'DUNGEON_RETURN' });
+      assert.ok(result);
+      assert.equal(result.phase, 'dungeon');
+      assert.equal(result.inDungeonCombat, undefined);
+    });
+
+    it('should clear floor on boss victory', () => {
+      const ds = { ...enterDungeon(createDungeonState()), currentFloor: 3 };
+      const state = {
+        ...makeDungeonState({ dungeonState: ds }),
+        phase: 'battle-summary',
+        inDungeonCombat: true,
+        dungeonBossFight: true,
+      };
+      const result = handleDungeonAction(state, { type: 'DUNGEON_RETURN' });
+      assert.ok(result);
+      assert.equal(result.phase, 'dungeon');
+      assert.ok(result.dungeonState.floorsCleared.includes(3));
+      assert.equal(result.dungeonBossFight, undefined);
+    });
+
+    it('should return null if not in dungeon combat', () => {
+      const state = makeDungeonState();
+      const result = handleDungeonAction(state, { type: 'DUNGEON_RETURN' });
+      assert.equal(result, null);
+    });
+  });
+
+  // === Unknown action ===
+  describe('Unknown actions', () => {
+    it('should return null for unknown action', () => {
+      const result = handleDungeonAction(makeState(), { type: 'UNKNOWN' });
+      assert.equal(result, null);
+    });
+
+    it('should return null for null action', () => {
+      const result = handleDungeonAction(makeState(), null);
+      assert.equal(result, null);
+    });
+
+    it('should return null for action without type', () => {
+      const result = handleDungeonAction(makeState(), {});
+      assert.equal(result, null);
+    });
+  });
+});


### PR DESCRIPTION
## Dungeon UI Integration

Wires the dungeon-floors.js system (merged in PR #200) into actual gameplay.

### New Files
- **src/handlers/dungeon-handler.js** — Handles 6 dungeon actions: ENTER_DUNGEON, DUNGEON_SEARCH, DUNGEON_ADVANCE, DUNGEON_FIGHT_BOSS, DUNGEON_EXIT, DUNGEON_RETURN
- **src/dungeon-ui.js** — Renders dungeon exploration panel with floor info, progress bar, themed colors/icons (7 themes), and action buttons
- **tests/dungeon-handler-test.mjs** — 29 passing tests covering all dungeon actions

### Modified Files
- **src/main.js** — Dungeon handler added to dispatch chain
- **src/render.js** — New 'dungeon' phase rendering + 'Enter Dungeon' button at Southwest Marsh (player level >= 3)
- **src/handlers/ui-handler.js** — CONTINUE_AFTER_BATTLE returns to dungeon phase when in dungeon combat; imports clearDungeonFloor

### Gameplay Flow
1. Player visits Southwest Marsh at level 3+ and sees 'Enter Dungeon' button
2. Entering transitions to dungeon phase with floor 1
3. Search Floor: random encounters with scaled enemies, or discover stairs, or find nothing
4. Fight Boss: available on boss floors (3, 6, 9, 10)
5. Descend: advance to next floor after finding stairs and clearing current floor
6. Exit: return to exploration, progress preserved
7. Combat in dungeon returns to dungeon phase (not exploration)

### No egg references - clean villager PR