### PR TITLE
feat: add provisions system with food/consumable buffs (53 tests)

### DIFF
--- a/src/provisions.js
+++ b/src/provisions.js
@@ -1,0 +1,325 @@
+export const PROVISIONS = {
+  travelerBread: {
+    id: "travelerBread",
+    name: "Traveler's Bread",
+    type: "provision",
+    category: "food",
+    rarity: "Common",
+    description: "A crusty trail loaf that steadies the stomach and mends small wounds over time.",
+    value: 10,
+    effect: { hpRegen: 2, duration: 5 }
+  },
+  heartyStew: {
+    id: "heartyStew",
+    name: "Hearty Stew",
+    type: "provision",
+    category: "food",
+    rarity: "Uncommon",
+    description: "A thick caravan stew that fortifies muscle and resolve for a long march.",
+    value: 25,
+    effect: { atkBoost: 3, defBoost: 2, duration: 8 }
+  },
+  roastedMeat: {
+    id: "roastedMeat",
+    name: "Roasted Meat",
+    type: "provision",
+    category: "food",
+    rarity: "Common",
+    description: "Flame-seared cuts that restore vigor immediately and keep strength flowing.",
+    value: 18,
+    effect: { healInstant: 30, hpRegen: 1, duration: 3 }
+  },
+  herbTea: {
+    id: "herbTea",
+    name: "Herb Tea",
+    type: "provision",
+    category: "drink",
+    rarity: "Common",
+    description: "A fragrant brew that clears the mind and renews arcane focus.",
+    value: 15,
+    effect: { mpInstant: 15, mpRegen: 2, duration: 4 }
+  },
+  ironRation: {
+    id: "ironRation",
+    name: "Iron Ration",
+    type: "provision",
+    category: "food",
+    rarity: "Uncommon",
+    description: "A salted war ration that hardens the body and sustains slow healing.",
+    value: 35,
+    effect: { atkBoost: 2, defBoost: 2, hpRegen: 1, duration: 10 }
+  },
+  dragonPepper: {
+    id: "dragonPepper",
+    name: "Dragon Pepper Soup",
+    type: "provision",
+    category: "food",
+    rarity: "Rare",
+    description: "A searing crimson soup that ignites fierce strength for a few turns.",
+    value: 50,
+    effect: { atkBoost: 5, duration: 6 }
+  },
+  frostBerry: {
+    id: "frostBerry",
+    name: "Frost Berry Tart",
+    type: "provision",
+    category: "food",
+    rarity: "Rare",
+    description: "A chilled tart whose sweet frost hardens defenses against harm.",
+    value: 50,
+    effect: { defBoost: 5, duration: 6 }
+  },
+  wardensMeal: {
+    id: "wardensMeal",
+    name: "Warden's Feast",
+    type: "provision",
+    category: "food",
+    rarity: "Epic",
+    description: "A guardian's banquet that grants stalwart power and deep restoration.",
+    value: 100,
+    effect: { atkBoost: 4, defBoost: 4, hpRegen: 3, mpRegen: 2, duration: 12 }
+  },
+  fieldMushroom: {
+    id: "fieldMushroom",
+    name: "Field Mushroom",
+    type: "provision",
+    category: "food",
+    rarity: "Common",
+    description: "A hardy wildcap that quickly closes minor wounds.",
+    value: 8,
+    effect: { healInstant: 15 }
+  },
+  spicedCider: {
+    id: "spicedCider",
+    name: "Spiced Cider",
+    type: "provision",
+    category: "drink",
+    rarity: "Uncommon",
+    description: "A warm cider with ember spices that lifts willpower and battle focus.",
+    value: 22,
+    effect: { atkBoost: 2, mpInstant: 10, duration: 5 }
+  }
+};
+
+export const COOKING_RECIPES = [
+  {
+    id: "cookHeartyStew",
+    name: "Cook Hearty Stew",
+    description: "Simmer herbs with a hearty base to craft a fortifying stew.",
+    ingredients: [
+      { itemId: "herbBundle", quantity: 2 },
+      { itemId: "roastedMeat", quantity: 1 }
+    ],
+    result: { itemId: "heartyStew", quantity: 1 },
+    requiredLevel: 2
+  },
+  {
+    id: "cookDragonPepper",
+    name: "Cook Dragon Pepper Soup",
+    description: "Blend dragon spice with herbs for a fiery, strength-granting soup.",
+    ingredients: [
+      { itemId: "dragonScale", quantity: 1 },
+      { itemId: "herbBundle", quantity: 2 }
+    ],
+    result: { itemId: "dragonPepper", quantity: 1 },
+    requiredLevel: 4
+  },
+  {
+    id: "cookWardensMeal",
+    name: "Cook Warden's Feast",
+    description: "Combine rare dishes into a guardian's feast of enduring power.",
+    ingredients: [
+      { itemId: "heartyStew", quantity: 1 },
+      { itemId: "dragonPepper", quantity: 1 },
+      { itemId: "frostBerry", quantity: 1 }
+    ],
+    result: { itemId: "wardensMeal", quantity: 1 },
+    requiredLevel: 6
+  },
+  {
+    id: "cookFrostBerry",
+    name: "Cook Frost Berry Tart",
+    description: "Bake enchanted berries into a tart that bolsters defense.",
+    ingredients: [
+      { itemId: "herbBundle", quantity: 2 },
+      { itemId: "arcaneEssence", quantity: 1 }
+    ],
+    result: { itemId: "frostBerry", quantity: 1 },
+    requiredLevel: 3
+  }
+];
+
+export function createProvisionState() {
+  return { activeBuffs: [], provisionsUsed: 0 };
+}
+
+function getInventoryItem(state, itemId) {
+  return state?.player?.inventory?.find((item) => item.id === itemId) || null;
+}
+
+function removeInventoryItem(state, itemId, quantity) {
+  const inventory = state.player.inventory;
+  const index = inventory.findIndex((item) => item.id === itemId);
+  if (index === -1) return false;
+  inventory[index].quantity -= quantity;
+  if (inventory[index].quantity <= 0) {
+    inventory.splice(index, 1);
+  }
+  return true;
+}
+
+function applyInstantEffects(state, effect) {
+  const player = state.player;
+  const messages = [];
+  if (effect.healInstant) {
+    const before = player.hp;
+    player.hp = Math.min(player.maxHp, player.hp + effect.healInstant);
+    const healed = player.hp - before;
+    if (healed > 0) messages.push(`Restored ${healed} HP.`);
+  }
+  if (effect.mpInstant) {
+    const before = player.mp;
+    player.mp = Math.min(player.maxMp, player.mp + effect.mpInstant);
+    const restored = player.mp - before;
+    if (restored > 0) messages.push(`Restored ${restored} MP.`);
+  }
+  return messages;
+}
+
+function addBuff(state, provision) {
+  const effect = provision.effect || {};
+  if (!effect.duration) return null;
+  const buff = {
+    id: provision.id,
+    name: provision.name,
+    turnsRemaining: effect.duration,
+    atkBoost: effect.atkBoost || 0,
+    defBoost: effect.defBoost || 0,
+    hpRegen: effect.hpRegen || 0,
+    mpRegen: effect.mpRegen || 0
+  };
+  state.provisionState.activeBuffs.push(buff);
+  return buff;
+}
+
+export function useProvision(state, provisionId) {
+  const provision = PROVISIONS[provisionId];
+  if (!provision) {
+    return { success: false, message: "Provision not found.", state };
+  }
+  if (!state?.player?.inventory) {
+    return { success: false, message: "No inventory available.", state };
+  }
+  if (!state.provisionState) {
+    state.provisionState = createProvisionState();
+  }
+  const inventoryItem = getInventoryItem(state, provisionId);
+  if (!inventoryItem || inventoryItem.quantity <= 0) {
+    return { success: false, message: "You do not have that provision.", state };
+  }
+
+  const instantMessages = applyInstantEffects(state, provision.effect || {});
+  const buff = addBuff(state, provision);
+  removeInventoryItem(state, provisionId, 1);
+
+  state.provisionState.provisionsUsed += 1;
+
+  let message = `Used ${provision.name}.`;
+  if (instantMessages.length > 0) {
+    message += ` ${instantMessages.join(" ")}`;
+  }
+  if (buff) {
+    message += ` Buff lasts ${buff.turnsRemaining} turns.`;
+  }
+
+  return { success: true, message, state };
+}
+
+export function tickProvisionBuffs(state) {
+  if (!state?.provisionState?.activeBuffs) {
+    return { state, messages: [] };
+  }
+  const player = state.player;
+  const messages = [];
+  let totalHpRegen = 0;
+  let totalMpRegen = 0;
+
+  for (const buff of state.provisionState.activeBuffs) {
+    totalHpRegen += buff.hpRegen || 0;
+    totalMpRegen += buff.mpRegen || 0;
+  }
+
+  if (totalHpRegen > 0) {
+    const before = player.hp;
+    player.hp = Math.min(player.maxHp, player.hp + totalHpRegen);
+    const healed = player.hp - before;
+    if (healed > 0) messages.push(`Regenerated ${healed} HP from provisions.`);
+  }
+
+  if (totalMpRegen > 0) {
+    const before = player.mp;
+    player.mp = Math.min(player.maxMp, player.mp + totalMpRegen);
+    const restored = player.mp - before;
+    if (restored > 0) messages.push(`Regenerated ${restored} MP from provisions.`);
+  }
+
+  for (const buff of state.provisionState.activeBuffs) {
+    buff.turnsRemaining -= 1;
+  }
+
+  const remaining = [];
+  for (const buff of state.provisionState.activeBuffs) {
+    if (buff.turnsRemaining > 0) {
+      remaining.push(buff);
+    } else {
+      messages.push(`${buff.name} has worn off.`);
+    }
+  }
+  state.provisionState.activeBuffs = remaining;
+
+  return { state, messages };
+}
+
+export function getProvisionBonuses(state) {
+  const bonuses = { atkBoost: 0, defBoost: 0, hpRegen: 0, mpRegen: 0 };
+  const buffs = state?.provisionState?.activeBuffs || [];
+  for (const buff of buffs) {
+    bonuses.atkBoost += buff.atkBoost || 0;
+    bonuses.defBoost += buff.defBoost || 0;
+    bonuses.hpRegen += buff.hpRegen || 0;
+    bonuses.mpRegen += buff.mpRegen || 0;
+  }
+  return bonuses;
+}
+
+export function hasActiveBuff(state, provisionId) {
+  const buffs = state?.provisionState?.activeBuffs || [];
+  return buffs.some((buff) => buff.id === provisionId);
+}
+
+export function clearAllBuffs(state) {
+  if (!state.provisionState) {
+    state.provisionState = createProvisionState();
+    return state;
+  }
+  state.provisionState.activeBuffs = [];
+  return state;
+}
+
+export function getProvisionById(id) {
+  return PROVISIONS[id] || null;
+}
+
+export function canUseProvision(state, provisionId) {
+  if (!PROVISIONS[provisionId]) {
+    return { canUse: false, reason: "Provision not found." };
+  }
+  if (!state?.player?.inventory) {
+    return { canUse: false, reason: "No inventory available." };
+  }
+  const inventoryItem = getInventoryItem(state, provisionId);
+  if (!inventoryItem || inventoryItem.quantity <= 0) {
+    return { canUse: false, reason: "You do not have that provision." };
+  }
+  return { canUse: true, reason: "" };
+}

--- a/tests/provisions-test.mjs
+++ b/tests/provisions-test.mjs
@@ -1,0 +1,429 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import {
+  PROVISIONS,
+  COOKING_RECIPES,
+  createProvisionState,
+  useProvision,
+  tickProvisionBuffs,
+  getProvisionBonuses,
+  hasActiveBuff,
+  clearAllBuffs,
+  getProvisionById,
+  canUseProvision,
+} from '../src/provisions.js';
+
+function baseState(overrides = {}) {
+  return {
+    player: { hp: 50, maxHp: 100, mp: 20, maxMp: 50, level: 5, inventory: {}, ...overrides.player },
+    provisionState: overrides.provisionState || createProvisionState(),
+    ...overrides,
+  };
+}
+
+describe('PROVISIONS data', () => {
+  it('has 10 provisions defined', () => {
+    assert.equal(Object.keys(PROVISIONS).length, 10);
+  });
+
+  it('each provision has id, name, type, category, rarity, description, value, effect', () => {
+    const required = ['id', 'name', 'type', 'category', 'rarity', 'description', 'value', 'effect'];
+    Object.values(PROVISIONS).forEach((provision) => {
+      required.forEach((prop) => {
+        assert.ok(prop in provision, `${provision.id} missing ${prop}`);
+      });
+    });
+  });
+
+  it("all provision types are 'provision'", () => {
+    Object.values(PROVISIONS).forEach((provision) => {
+      assert.equal(provision.type, 'provision');
+    });
+  });
+
+  it('no egg references in any name or description', () => {
+    const banned = /egg|nest|chicken|hatch|yolk|shell|scrambl|omelet|poach/i;
+    Object.values(PROVISIONS).forEach((provision) => {
+      const text = `${provision.name} ${provision.description}`;
+      assert.equal(banned.test(text), false, `Egg reference found in ${provision.id}`);
+    });
+  });
+
+  it('travelerBread has correct stats', () => {
+    assert.deepEqual(PROVISIONS.travelerBread.effect, { hpRegen: 2, duration: 5 });
+    assert.equal(PROVISIONS.travelerBread.value, 10);
+  });
+
+  it('wardensMeal has correct stats', () => {
+    assert.deepEqual(PROVISIONS.wardensMeal.effect, {
+      atkBoost: 4,
+      defBoost: 4,
+      hpRegen: 3,
+      mpRegen: 2,
+      duration: 12,
+    });
+    assert.equal(PROVISIONS.wardensMeal.value, 100);
+  });
+
+  it('fieldMushroom has healInstant:15 and no duration', () => {
+    assert.equal(PROVISIONS.fieldMushroom.effect.healInstant, 15);
+    assert.equal('duration' in PROVISIONS.fieldMushroom.effect, false);
+  });
+});
+
+describe('COOKING_RECIPES', () => {
+  it('has 4 recipes', () => {
+    assert.equal(COOKING_RECIPES.length, 4);
+  });
+
+  it('each recipe has id, name, description, ingredients, result, requiredLevel', () => {
+    const required = ['id', 'name', 'description', 'ingredients', 'result', 'requiredLevel'];
+    COOKING_RECIPES.forEach((recipe) => {
+      required.forEach((prop) => {
+        assert.ok(prop in recipe, `${recipe.id} missing ${prop}`);
+      });
+    });
+  });
+
+  it('cookHeartyStew requires level 2', () => {
+    const recipe = COOKING_RECIPES.find((entry) => entry.id === 'cookHeartyStew');
+    assert.ok(recipe);
+    assert.equal(recipe.requiredLevel, 2);
+  });
+
+  it('cookWardensMeal requires level 6', () => {
+    const recipe = COOKING_RECIPES.find((entry) => entry.id === 'cookWardensMeal');
+    assert.ok(recipe);
+    assert.equal(recipe.requiredLevel, 6);
+  });
+
+  it('all recipe results reference valid provision IDs', () => {
+    COOKING_RECIPES.forEach((recipe) => {
+      assert.ok(PROVISIONS[recipe.result.itemId], `${recipe.id} result invalid`);
+    });
+  });
+});
+
+describe('createProvisionState', () => {
+  it('returns object with activeBuffs as empty array', () => {
+    const state = createProvisionState();
+    assert.ok(Array.isArray(state.activeBuffs));
+    assert.equal(state.activeBuffs.length, 0);
+  });
+
+  it('returns object with provisionsUsed as 0', () => {
+    const state = createProvisionState();
+    assert.equal(state.provisionsUsed, 0);
+  });
+
+  it('each call returns a new object', () => {
+    const first = createProvisionState();
+    const second = createProvisionState();
+    assert.notEqual(first, second);
+  });
+});
+
+describe('useProvision', () => {
+  it('successfully uses a provision from inventory', () => {
+    const state = baseState({ player: { inventory: [{ id: 'travelerBread', quantity: 1 }] } });
+    const result = useProvision(state, 'travelerBread');
+    assert.equal(result.success, true);
+  });
+
+  it('returns success:true with message', () => {
+    const state = baseState({ player: { inventory: [{ id: 'travelerBread', quantity: 1 }] } });
+    const result = useProvision(state, 'travelerBread');
+    assert.equal(result.success, true);
+    assert.equal(typeof result.message, 'string');
+    assert.ok(result.message.includes('Used'));
+  });
+
+  it('reduces inventory count by 1', () => {
+    const state = baseState({ player: { inventory: [{ id: 'travelerBread', quantity: 2 }] } });
+    useProvision(state, 'travelerBread');
+    assert.equal(state.player.inventory[0].quantity, 1);
+  });
+
+  it('removes inventory entry when quantity hits zero', () => {
+    const state = baseState({ player: { inventory: [{ id: 'travelerBread', quantity: 1 }] } });
+    useProvision(state, 'travelerBread');
+    assert.equal(state.player.inventory.length, 0);
+  });
+
+  it('adds buff to activeBuffs for duration-based provisions', () => {
+    const state = baseState({ player: { inventory: [{ id: 'travelerBread', quantity: 1 }] } });
+    useProvision(state, 'travelerBread');
+    assert.equal(state.provisionState.activeBuffs.length, 1);
+    assert.equal(state.provisionState.activeBuffs[0].id, 'travelerBread');
+  });
+
+  it('applies instant healing for roastedMeat (healInstant:30)', () => {
+    const state = baseState();
+    state.player.hp = 50;
+    state.player.inventory = [{ id: 'roastedMeat', quantity: 1 }];
+    useProvision(state, 'roastedMeat');
+    assert.equal(state.player.hp, 80);
+  });
+
+  it('applies instant MP for herbTea (mpInstant:15)', () => {
+    const state = baseState();
+    state.player.mp = 20;
+    state.player.inventory = [{ id: 'herbTea', quantity: 1 }];
+    useProvision(state, 'herbTea');
+    assert.equal(state.player.mp, 35);
+  });
+
+  it('fails when player does not have the item', () => {
+    const state = baseState({ player: { inventory: [{ id: 'travelerBread', quantity: 0 }] } });
+    const result = useProvision(state, 'travelerBread');
+    assert.equal(result.success, false);
+    assert.ok(result.message.includes('do not have'));
+  });
+
+  it('fails when provisionId is invalid', () => {
+    const state = baseState({ player: { inventory: [{ id: 'travelerBread', quantity: 1 }] } });
+    const result = useProvision(state, 'missingProvision');
+    assert.equal(result.success, false);
+    assert.ok(result.message.includes('not found'));
+  });
+
+  it('fails when no inventory exists', () => {
+    const state = baseState({ player: { inventory: null } });
+    const result = useProvision(state, 'travelerBread');
+    assert.equal(result.success, false);
+    assert.ok(result.message.includes('No inventory'));
+  });
+
+  it('increments provisionsUsed counter', () => {
+    const state = baseState({ player: { inventory: [{ id: 'travelerBread', quantity: 1 }] } });
+    useProvision(state, 'travelerBread');
+    assert.equal(state.provisionState.provisionsUsed, 1);
+  });
+
+  it('initializes provisionState if missing', () => {
+    const state = {
+      player: { hp: 50, maxHp: 100, mp: 20, maxMp: 50, level: 5, inventory: [{ id: 'travelerBread', quantity: 1 }] },
+    };
+    useProvision(state, 'travelerBread');
+    assert.ok(state.provisionState);
+    assert.equal(state.provisionState.provisionsUsed, 1);
+  });
+});
+
+describe('tickProvisionBuffs', () => {
+  it('applies HP regen from active buffs', () => {
+    const state = baseState({
+      player: { hp: 40, maxHp: 100 },
+      provisionState: { activeBuffs: [{ hpRegen: 5, mpRegen: 0, turnsRemaining: 2, id: 'buff', name: 'Buff' }], provisionsUsed: 0 },
+    });
+    tickProvisionBuffs(state);
+    assert.equal(state.player.hp, 45);
+  });
+
+  it('applies MP regen from active buffs', () => {
+    const state = baseState({
+      player: { mp: 10, maxMp: 50 },
+      provisionState: { activeBuffs: [{ hpRegen: 0, mpRegen: 4, turnsRemaining: 2, id: 'buff', name: 'Buff' }], provisionsUsed: 0 },
+    });
+    tickProvisionBuffs(state);
+    assert.equal(state.player.mp, 14);
+  });
+
+  it('decrements turnsRemaining', () => {
+    const state = baseState({
+      provisionState: { activeBuffs: [{ hpRegen: 1, mpRegen: 0, turnsRemaining: 2, id: 'buff', name: 'Buff' }], provisionsUsed: 0 },
+    });
+    tickProvisionBuffs(state);
+    assert.equal(state.provisionState.activeBuffs[0].turnsRemaining, 1);
+  });
+
+  it('removes expired buffs', () => {
+    const state = baseState({
+      provisionState: { activeBuffs: [{ hpRegen: 1, mpRegen: 0, turnsRemaining: 1, id: 'buff', name: 'Buff' }], provisionsUsed: 0 },
+    });
+    tickProvisionBuffs(state);
+    assert.equal(state.provisionState.activeBuffs.length, 0);
+  });
+
+  it('returns messages about regen', () => {
+    const state = baseState({
+      provisionState: { activeBuffs: [{ hpRegen: 2, mpRegen: 3, turnsRemaining: 2, id: 'buff', name: 'Buff' }], provisionsUsed: 0 },
+    });
+    const result = tickProvisionBuffs(state);
+    assert.ok(result.messages.some((msg) => msg.includes('Regenerated')));
+  });
+
+  it('returns message when buff expires', () => {
+    const state = baseState({
+      provisionState: { activeBuffs: [{ hpRegen: 0, mpRegen: 0, turnsRemaining: 1, id: 'buff', name: 'Buff' }], provisionsUsed: 0 },
+    });
+    const result = tickProvisionBuffs(state);
+    assert.ok(result.messages.some((msg) => msg.includes('worn off')));
+  });
+
+  it('does nothing when no buffs active', () => {
+    const state = baseState({ provisionState: { activeBuffs: [], provisionsUsed: 0 } });
+    const result = tickProvisionBuffs(state);
+    assert.equal(result.messages.length, 0);
+  });
+
+  it('does nothing when provisionState is null', () => {
+    const state = {
+      player: { hp: 50, maxHp: 100, mp: 20, maxMp: 50, level: 5, inventory: [] },
+      provisionState: null,
+    };
+    const result = tickProvisionBuffs(state);
+    assert.equal(result.messages.length, 0);
+  });
+
+  it('caps HP at maxHp', () => {
+    const state = baseState({
+      player: { hp: 99, maxHp: 100 },
+      provisionState: { activeBuffs: [{ hpRegen: 5, mpRegen: 0, turnsRemaining: 2, id: 'buff', name: 'Buff' }], provisionsUsed: 0 },
+    });
+    tickProvisionBuffs(state);
+    assert.equal(state.player.hp, 100);
+  });
+
+  it('caps MP at maxMp', () => {
+    const state = baseState({
+      player: { mp: 49, maxMp: 50 },
+      provisionState: { activeBuffs: [{ hpRegen: 0, mpRegen: 5, turnsRemaining: 2, id: 'buff', name: 'Buff' }], provisionsUsed: 0 },
+    });
+    tickProvisionBuffs(state);
+    assert.equal(state.player.mp, 50);
+  });
+});
+
+describe('getProvisionBonuses', () => {
+  it('returns zero bonuses when no buffs', () => {
+    const state = baseState({ provisionState: { activeBuffs: [], provisionsUsed: 0 } });
+    assert.deepEqual(getProvisionBonuses(state), { atkBoost: 0, defBoost: 0, hpRegen: 0, mpRegen: 0 });
+  });
+
+  it('aggregates atkBoost from multiple buffs', () => {
+    const state = baseState({
+      provisionState: {
+        activeBuffs: [
+          { atkBoost: 2, defBoost: 0, hpRegen: 0, mpRegen: 0 },
+          { atkBoost: 3, defBoost: 0, hpRegen: 0, mpRegen: 0 },
+        ],
+        provisionsUsed: 0,
+      },
+    });
+    assert.equal(getProvisionBonuses(state).atkBoost, 5);
+  });
+
+  it('aggregates defBoost from multiple buffs', () => {
+    const state = baseState({
+      provisionState: {
+        activeBuffs: [
+          { atkBoost: 0, defBoost: 1, hpRegen: 0, mpRegen: 0 },
+          { atkBoost: 0, defBoost: 4, hpRegen: 0, mpRegen: 0 },
+        ],
+        provisionsUsed: 0,
+      },
+    });
+    assert.equal(getProvisionBonuses(state).defBoost, 5);
+  });
+
+  it('handles mixed buffs correctly', () => {
+    const state = baseState({
+      provisionState: {
+        activeBuffs: [
+          { atkBoost: 2, defBoost: 1, hpRegen: 1, mpRegen: 0 },
+          { atkBoost: 1, defBoost: 0, hpRegen: 0, mpRegen: 3 },
+        ],
+        provisionsUsed: 0,
+      },
+    });
+    assert.deepEqual(getProvisionBonuses(state), { atkBoost: 3, defBoost: 1, hpRegen: 1, mpRegen: 3 });
+  });
+});
+
+describe('hasActiveBuff', () => {
+  it('returns false when no buffs', () => {
+    const state = baseState({ provisionState: { activeBuffs: [], provisionsUsed: 0 } });
+    assert.equal(hasActiveBuff(state, 'travelerBread'), false);
+  });
+
+  it('returns true when buff is active', () => {
+    const state = baseState({
+      provisionState: { activeBuffs: [{ id: 'travelerBread' }], provisionsUsed: 0 },
+    });
+    assert.equal(hasActiveBuff(state, 'travelerBread'), true);
+  });
+
+  it('returns false for inactive buff', () => {
+    const state = baseState({
+      provisionState: { activeBuffs: [{ id: 'travelerBread' }], provisionsUsed: 0 },
+    });
+    assert.equal(hasActiveBuff(state, 'wardensMeal'), false);
+  });
+});
+
+describe('clearAllBuffs', () => {
+  it('removes all active buffs', () => {
+    const state = baseState({
+      provisionState: { activeBuffs: [{ id: 'travelerBread' }], provisionsUsed: 0 },
+    });
+    clearAllBuffs(state);
+    assert.equal(state.provisionState.activeBuffs.length, 0);
+  });
+
+  it('initializes provisionState if missing', () => {
+    const state = { player: { hp: 50, maxHp: 100, mp: 20, maxMp: 50, level: 5, inventory: [] } };
+    clearAllBuffs(state);
+    assert.ok(state.provisionState);
+    assert.equal(state.provisionState.activeBuffs.length, 0);
+  });
+
+  it('returns state with empty activeBuffs', () => {
+    const state = baseState({
+      provisionState: { activeBuffs: [{ id: 'travelerBread' }], provisionsUsed: 2 },
+    });
+    const result = clearAllBuffs(state);
+    assert.equal(result.provisionState.activeBuffs.length, 0);
+  });
+});
+
+describe('getProvisionById', () => {
+  it('returns provision for valid ID', () => {
+    const provision = getProvisionById('travelerBread');
+    assert.ok(provision);
+    assert.equal(provision.id, 'travelerBread');
+  });
+
+  it('returns null for invalid ID', () => {
+    assert.equal(getProvisionById('missingProvision'), null);
+  });
+});
+
+describe('canUseProvision', () => {
+  it('returns canUse:true when player has item', () => {
+    const state = baseState({ player: { inventory: [{ id: 'travelerBread', quantity: 1 }] } });
+    const result = canUseProvision(state, 'travelerBread');
+    assert.equal(result.canUse, true);
+  });
+
+  it('returns canUse:false when item not in inventory', () => {
+    const state = baseState({ player: { inventory: [] } });
+    const result = canUseProvision(state, 'travelerBread');
+    assert.equal(result.canUse, false);
+    assert.ok(result.reason.includes('do not have'));
+  });
+
+  it('returns canUse:false for invalid provision ID', () => {
+    const state = baseState({ player: { inventory: [{ id: 'travelerBread', quantity: 1 }] } });
+    const result = canUseProvision(state, 'missingProvision');
+    assert.equal(result.canUse, false);
+    assert.ok(result.reason.includes('not found'));
+  });
+
+  it('returns canUse:false when no inventory', () => {
+    const state = baseState({ player: { inventory: null } });
+    const result = canUseProvision(state, 'travelerBread');
+    assert.equal(result.canUse, false);
+    assert.ok(result.reason.includes('No inventory'));
+  });
+});


### PR DESCRIPTION
## Provisions System

Clean replacement for the saboteur's egg-laden food PR #180.

### New Files
- **src/provisions.js** (325 lines) - Complete provisions/food system
- **tests/provisions-test.mjs** (429 lines) - 53 comprehensive tests

### Features
- **10 Provisions**: Traveler's Bread, Hearty Stew, Roasted Meat, Herb Tea, Iron Ration, Dragon Pepper Soup, Frost Berry Tart, Warden's Feast, Field Mushroom, Spiced Cider
- **4 Cooking Recipes**: Integrate with existing crafting materials (herbBundle, dragonScale, arcaneEssence)
- **Buff System**: Temporary combat buffs (ATK/DEF boost, HP/MP regen) with turn-based expiry
- **Full Lifecycle**: use provision -> apply instant effects + add duration buff -> tick each turn -> expire with messages

### API
- createProvisionState(), useProvision(), tickProvisionBuffs()
- getProvisionBonuses(), hasActiveBuff(), clearAllBuffs()
- getProvisionById(), canUseProvision()

### Security
- NO egg references anywhere in code (verified with grep)
- Fantasy-themed item names and descriptions only
- Self-contained module, no modifications to existing files

### Tests: 53 passing
- Data integrity (provisions, recipes)
- State creation and management
- Provision usage with inventory integration
- Buff ticking, expiry, and HP/MP capping
- Bonus aggregation from multiple buffs
- Edge cases (missing inventory, invalid IDs, null state)