### PR TITLE
feat: Provisions UI integration (handler + UI + 35 tests)

### DIFF
--- a/src/handlers/provisions-handler.js
+++ b/src/handlers/provisions-handler.js
@@ -1,0 +1,204 @@
+import {
+  useProvision,
+  tickProvisionBuffs,
+  getProvisionBonuses,
+  canUseProvision,
+  createProvisionState,
+  PROVISIONS,
+  COOKING_RECIPES,
+} from '../provisions.js';
+import { pushLog } from '../state.js';
+
+/**
+ * Handle provision-related actions.
+ * @param {object} state - Current game state
+ * @param {object} action - Action to handle
+ * @returns {object|null} Updated state, or null if action not handled
+ */
+export function handleProvisionAction(state, action) {
+  if (!action || !action.type) return null;
+
+  if (action.type === 'OPEN_PROVISIONS') {
+    if (state.phase === 'class-select') return null;
+    return {
+      ...state,
+      phase: 'provisions',
+      previousPhase: state.phase,
+      provisionsUI: { selectedProvision: null, message: null, tab: 'use' },
+    };
+  }
+
+  if (action.type === 'CLOSE_PROVISIONS') {
+    if (state.phase !== 'provisions') return null;
+    const returnPhase = state.previousPhase || 'exploration';
+    return { ...state, phase: returnPhase, provisionsUI: undefined };
+  }
+
+  if (action.type === 'PROVISIONS_SELECT') {
+    if (state.phase !== 'provisions') return null;
+    return {
+      ...state,
+      provisionsUI: {
+        ...state.provisionsUI,
+        selectedProvision: action.provisionId || null,
+        message: null,
+      },
+    };
+  }
+
+  if (action.type === 'PROVISIONS_SWITCH_TAB') {
+    if (state.phase !== 'provisions') return null;
+    return {
+      ...state,
+      provisionsUI: {
+        ...state.provisionsUI,
+        tab: action.tab || 'use',
+        selectedProvision: null,
+        message: null,
+      },
+    };
+  }
+
+  if (action.type === 'USE_PROVISION') {
+    if (!action.provisionId) return null;
+
+    if (!state.provisionState) {
+      state = { ...state, provisionState: createProvisionState() };
+    }
+
+    const check = canUseProvision(state, action.provisionId);
+    if (!check.canUse) {
+      if (state.phase === 'provisions') {
+        return {
+          ...state,
+          provisionsUI: { ...state.provisionsUI, message: check.reason },
+        };
+      }
+      return pushLog(state, check.reason);
+    }
+
+    const result = useProvision(state, action.provisionId);
+    if (!result.success) {
+      if (state.phase === 'provisions') {
+        return {
+          ...result.state,
+          provisionsUI: { ...state.provisionsUI, message: result.message },
+        };
+      }
+      return pushLog(result.state, result.message);
+    }
+
+    let next = result.state;
+    if (state.phase === 'provisions') {
+      next = {
+        ...next,
+        provisionsUI: {
+          ...state.provisionsUI,
+          message: result.message,
+          selectedProvision: null,
+        },
+      };
+    }
+    return pushLog(next, result.message);
+  }
+
+  if (action.type === 'TICK_PROVISIONS') {
+    if (!state.provisionState) return null;
+    const result = tickProvisionBuffs(state);
+    let next = result.state;
+    for (const msg of result.messages) {
+      next = pushLog(next, msg);
+    }
+    return next;
+  }
+
+  if (action.type === 'COOK_PROVISION') {
+    if (state.phase !== 'provisions') return null;
+    const recipeId = action.recipeId;
+    if (!recipeId) return null;
+
+    const recipe = COOKING_RECIPES.find((r) => r.id === recipeId);
+    if (!recipe) {
+      return {
+        ...state,
+        provisionsUI: { ...state.provisionsUI, message: 'Recipe not found.' },
+      };
+    }
+
+    if (state.player.level < recipe.requiredLevel) {
+      return {
+        ...state,
+        provisionsUI: {
+          ...state.provisionsUI,
+          message: `Requires level ${recipe.requiredLevel}. You are level ${state.player.level}.`,
+        },
+      };
+    }
+
+    const inventory = state.player.inventory || [];
+    for (const ingredient of recipe.ingredients) {
+      const item = inventory.find((i) => i.id === ingredient.itemId);
+      if (!item || item.quantity < ingredient.quantity) {
+        return {
+          ...state,
+          provisionsUI: {
+            ...state.provisionsUI,
+            message: `Missing ingredient: ${ingredient.itemId} (need ${ingredient.quantity}).`,
+          },
+        };
+      }
+    }
+
+    let newInventory = inventory.map((i) => ({ ...i }));
+    for (const ingredient of recipe.ingredients) {
+      const idx = newInventory.findIndex((i) => i.id === ingredient.itemId);
+      if (idx !== -1) {
+        newInventory[idx].quantity -= ingredient.quantity;
+        if (newInventory[idx].quantity <= 0) {
+          newInventory.splice(idx, 1);
+        }
+      }
+    }
+
+    const existingResult = newInventory.find((i) => i.id === recipe.result.itemId);
+    if (existingResult) {
+      existingResult.quantity += recipe.result.quantity;
+    } else {
+      const provisionData = PROVISIONS[recipe.result.itemId];
+      newInventory.push({
+        id: recipe.result.itemId,
+        name: provisionData ? provisionData.name : recipe.result.itemId,
+        type: 'provision',
+        quantity: recipe.result.quantity,
+      });
+    }
+
+    const msg = `Cooked ${recipe.name}! Received ${recipe.result.quantity}x ${recipe.result.itemId}.`;
+    let next = {
+      ...state,
+      player: { ...state.player, inventory: newInventory },
+      provisionsUI: { ...state.provisionsUI, message: msg },
+    };
+    return pushLog(next, msg);
+  }
+
+  return null;
+}
+
+/**
+ * Get summary of active provision buffs for display in combat/exploration.
+ * @param {object} state - Current game state
+ * @returns {{ totalAtk: number, totalDef: number, buffCount: number, buffNames: string[] }}
+ */
+export function getProvisionBuffSummary(state) {
+  const bonuses = getProvisionBonuses(state);
+  const buffs = state?.provisionState?.activeBuffs || [];
+  return {
+    totalAtk: bonuses.atkBoost,
+    totalDef: bonuses.defBoost,
+    totalHpRegen: bonuses.hpRegen,
+    totalMpRegen: bonuses.mpRegen,
+    buffCount: buffs.length,
+    buffNames: buffs.map((b) => b.name),
+  };
+}

--- a/src/provisions-ui.js
+++ b/src/provisions-ui.js
@@ -1,0 +1,325 @@
+// Provisions UI rendering module
+// Created by Claude Opus 4.6 (Villager) on Day 343
+// Lazy DOM access pattern: no top-level window/document references
+
+import { PROVISIONS, COOKING_RECIPES, getProvisionBonuses } from './provisions.js';
+
+const RARITY_COLORS = {
+  Common: '#aaa',
+  Uncommon: '#2ecc71',
+  Rare: '#3498db',
+  Epic: '#9b59b6',
+};
+
+const CATEGORY_ICONS = {
+  food: '🍖',
+  drink: '🧪',
+};
+
+function esc(s) {
+  return String(s)
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+}
+
+function formatEffect(effect) {
+  const parts = [];
+  if (effect.healInstant) parts.push(`+${effect.healInstant} HP`);
+  if (effect.mpInstant) parts.push(`+${effect.mpInstant} MP`);
+  if (effect.hpRegen) parts.push(`+${effect.hpRegen} HP/turn`);
+  if (effect.mpRegen) parts.push(`+${effect.mpRegen} MP/turn`);
+  if (effect.atkBoost) parts.push(`+${effect.atkBoost} ATK`);
+  if (effect.defBoost) parts.push(`+${effect.defBoost} DEF`);
+  if (effect.duration) parts.push(`${effect.duration} turns`);
+  return parts.join(', ');
+}
+
+/**
+ * Get provisions from the player inventory.
+ * @param {Array} inventory - Player inventory array
+ * @returns {Array} Provisions found in inventory with their data
+ */
+function getPlayerProvisions(inventory) {
+  if (!inventory) return [];
+  const results = [];
+  for (const item of inventory) {
+    const provData = PROVISIONS[item.id];
+    if (provData && item.quantity > 0) {
+      results.push({ ...provData, quantity: item.quantity });
+    }
+  }
+  return results;
+}
+
+/**
+ * Render the active buffs bar (usable from combat/exploration panels too).
+ * @param {object} state - Current game state
+ * @returns {string} HTML string for active buffs display
+ */
+export function renderProvisionBuffs(state) {
+  const buffs = state?.provisionState?.activeBuffs || [];
+  if (buffs.length === 0) return '';
+
+  const bonuses = getProvisionBonuses(state);
+  const buffCards = buffs.map((buff) => {
+    const parts = [];
+    if (buff.atkBoost) parts.push(`+${buff.atkBoost} ATK`);
+    if (buff.defBoost) parts.push(`+${buff.defBoost} DEF`);
+    if (buff.hpRegen) parts.push(`+${buff.hpRegen} HP/t`);
+    if (buff.mpRegen) parts.push(`+${buff.mpRegen} MP/t`);
+    return `<span class="provision-buff-chip" title="${esc(parts.join(', '))}">${esc(buff.name)} (${buff.turnsRemaining}t)</span>`;
+  }).join('');
+
+  let summaryParts = [];
+  if (bonuses.atkBoost) summaryParts.push(`+${bonuses.atkBoost} ATK`);
+  if (bonuses.defBoost) summaryParts.push(`+${bonuses.defBoost} DEF`);
+  const summaryText = summaryParts.length > 0 ? ` — ${summaryParts.join(', ')}` : '';
+
+  return `
+    <div class="provision-buffs-bar">
+      <span class="provision-buffs-label">🍖 Provisions${summaryText}:</span>
+      ${buffCards}
+    </div>
+  `;
+}
+
+/**
+ * Render the full provisions panel (opened via OPEN_PROVISIONS action).
+ * @param {object} state - Current game state
+ * @returns {string} HTML string
+ */
+export function renderProvisionsPanel(state) {
+  const ui = state.provisionsUI || { tab: 'use', selectedProvision: null, message: null };
+  const inventory = state.player?.inventory || [];
+  const provisions = getPlayerProvisions(inventory);
+  const buffs = state?.provisionState?.activeBuffs || [];
+
+  const tabUseClass = ui.tab === 'use' ? 'provisions-tab active' : 'provisions-tab';
+  const tabCookClass = ui.tab === 'cook' ? 'provisions-tab active' : 'provisions-tab';
+  const tabBuffsClass = ui.tab === 'buffs' ? 'provisions-tab active' : 'provisions-tab';
+
+  let contentHtml = '';
+  if (ui.tab === 'use') {
+    contentHtml = renderUseTab(provisions, ui.selectedProvision);
+  } else if (ui.tab === 'cook') {
+    contentHtml = renderCookTab(state);
+  } else if (ui.tab === 'buffs') {
+    contentHtml = renderBuffsTab(buffs);
+  }
+
+  const messageHtml = ui.message
+    ? `<div class="provisions-message">${esc(ui.message)}</div>`
+    : '';
+
+  return `
+    <div class="card provisions-panel">
+      <h2>🍖 Provisions</h2>
+      <p class="provisions-subtitle">Cook meals and consume provisions for combat buffs.</p>
+      ${messageHtml}
+      <div class="provisions-tabs">
+        <button class="${tabUseClass}" data-provisions-tab="use">Use</button>
+        <button class="${tabCookClass}" data-provisions-tab="cook">Cook</button>
+        <button class="${tabBuffsClass}" data-provisions-tab="buffs">Active Buffs (${buffs.length})</button>
+      </div>
+      <div class="provisions-content">
+        ${contentHtml}
+      </div>
+      <div class="buttons">
+        <button id="btnCloseProvisions">Close</button>
+      </div>
+    </div>
+  `;
+}
+
+function renderUseTab(provisions, selectedId) {
+  if (provisions.length === 0) {
+    return '<div class="provisions-empty">You have no provisions. Find or cook some!</div>';
+  }
+
+  const listHtml = provisions.map((prov) => {
+    const isSelected = selectedId === prov.id;
+    const rarityColor = RARITY_COLORS[prov.rarity] || '#aaa';
+    const icon = CATEGORY_ICONS[prov.category] || '🍖';
+    const effectText = formatEffect(prov.effect || {});
+
+    return `
+      <div class="provision-item${isSelected ? ' selected' : ''}" data-provision-id="${esc(prov.id)}">
+        <div class="provision-item-header">
+          <span class="provision-item-name" style="color:${rarityColor}">${icon} ${esc(prov.name)}</span>
+          <span class="provision-item-rarity" style="color:${rarityColor}">[${esc(prov.rarity)}]</span>
+          <span class="provision-item-qty">x${prov.quantity}</span>
+        </div>
+        <div class="provision-item-desc">${esc(prov.description)}</div>
+        <div class="provision-item-effect">${esc(effectText)}</div>
+        ${isSelected ? `<button class="provision-use-btn" data-use-provision="${esc(prov.id)}">Consume</button>` : ''}
+      </div>
+    `;
+  }).join('');
+
+  return `<div class="provision-list">${listHtml}</div>`;
+}
+
+function renderCookTab(state) {
+  const inventory = state.player?.inventory || [];
+  const playerLevel = state.player?.level || 1;
+
+  if (COOKING_RECIPES.length === 0) {
+    return '<div class="provisions-empty">No recipes available.</div>';
+  }
+
+  const recipesHtml = COOKING_RECIPES.map((recipe) => {
+    const canCook = playerLevel >= recipe.requiredLevel;
+    const ingredientsHtml = recipe.ingredients.map((ing) => {
+      const item = inventory.find((i) => i.id === ing.itemId);
+      const have = item ? item.quantity : 0;
+      const enough = have >= ing.quantity;
+      return `<span class="recipe-ingredient${enough ? ' has-enough' : ' not-enough'}">${esc(ing.itemId)} ${have}/${ing.quantity}</span>`;
+    }).join(', ');
+
+    const resultProv = PROVISIONS[recipe.result.itemId];
+    const resultName = resultProv ? resultProv.name : recipe.result.itemId;
+
+    const hasAllIngredients = recipe.ingredients.every((ing) => {
+      const item = inventory.find((i) => i.id === ing.itemId);
+      return item && item.quantity >= ing.quantity;
+    });
+
+    const canCookNow = canCook && hasAllIngredients;
+
+    return `
+      <div class="recipe-card${canCookNow ? '' : ' recipe-locked'}">
+        <div class="recipe-header">
+          <span class="recipe-name">${esc(recipe.name)}</span>
+          <span class="recipe-level">${canCook ? '' : '🔒 '}Lv.${recipe.requiredLevel}</span>
+        </div>
+        <div class="recipe-desc">${esc(recipe.description)}</div>
+        <div class="recipe-ingredients">Needs: ${ingredientsHtml}</div>
+        <div class="recipe-result">Result: ${esc(resultName)} x${recipe.result.quantity}</div>
+        <button class="recipe-cook-btn" data-cook-recipe="${esc(recipe.id)}" ${canCookNow ? '' : 'disabled'}>Cook</button>
+      </div>
+    `;
+  }).join('');
+
+  return `<div class="recipe-list">${recipesHtml}</div>`;
+}
+
+function renderBuffsTab(buffs) {
+  if (buffs.length === 0) {
+    return '<div class="provisions-empty">No active provision buffs.</div>';
+  }
+
+  const buffsHtml = buffs.map((buff) => {
+    const parts = [];
+    if (buff.atkBoost) parts.push(`+${buff.atkBoost} ATK`);
+    if (buff.defBoost) parts.push(`+${buff.defBoost} DEF`);
+    if (buff.hpRegen) parts.push(`+${buff.hpRegen} HP/turn`);
+    if (buff.mpRegen) parts.push(`+${buff.mpRegen} MP/turn`);
+    const effectText = parts.join(', ') || 'No stat bonuses';
+
+    return `
+      <div class="buff-card">
+        <div class="buff-header">
+          <span class="buff-name">🍖 ${esc(buff.name)}</span>
+          <span class="buff-turns">${buff.turnsRemaining} turns left</span>
+        </div>
+        <div class="buff-effects">${esc(effectText)}</div>
+      </div>
+    `;
+  }).join('');
+
+  return `<div class="buff-list">${buffsHtml}</div>`;
+}
+
+/**
+ * Attach event handlers for the provisions UI.
+ * Uses lazy DOM access (safe for Node.js testing).
+ * @param {Function} dispatch - Action dispatch function
+ */
+export function attachProvisionsHandlers(dispatch) {
+  const doc = typeof document !== 'undefined' ? document : null;
+  if (!doc) return;
+
+  const closeBtn = doc.getElementById('btnCloseProvisions');
+  if (closeBtn) closeBtn.onclick = () => dispatch({ type: 'CLOSE_PROVISIONS' });
+
+  const tabs = doc.querySelectorAll('[data-provisions-tab]');
+  tabs.forEach((tab) => {
+    tab.onclick = () => dispatch({ type: 'PROVISIONS_SWITCH_TAB', tab: tab.dataset.provisionsTab });
+  });
+
+  const items = doc.querySelectorAll('[data-provision-id]');
+  items.forEach((item) => {
+    item.onclick = (e) => {
+      if (e.target.closest('[data-use-provision]')) return;
+      dispatch({ type: 'PROVISIONS_SELECT', provisionId: item.dataset.provisionId });
+    };
+  });
+
+  const useBtns = doc.querySelectorAll('[data-use-provision]');
+  useBtns.forEach((btn) => {
+    btn.onclick = (e) => {
+      e.stopPropagation();
+      dispatch({ type: 'USE_PROVISION', provisionId: btn.dataset.useProvision });
+    };
+  });
+
+  const cookBtns = doc.querySelectorAll('[data-cook-recipe]');
+  cookBtns.forEach((btn) => {
+    btn.onclick = () => dispatch({ type: 'COOK_PROVISION', recipeId: btn.dataset.cookRecipe });
+  });
+}
+
+/**
+ * Get CSS styles for the provisions UI.
+ * @returns {string} CSS string
+ */
+export function getProvisionsStyles() {
+  return `
+    .provisions-panel { position: relative; }
+    .provisions-subtitle { font-style: italic; color: #aaa; margin: 4px 0 8px; font-size: 0.9em; }
+    .provisions-message { background: #2a3a2a; border-left: 3px solid #2ecc71; padding: 6px 10px; margin: 6px 0; font-size: 0.9em; }
+    .provisions-tabs { display: flex; gap: 4px; margin: 8px 0; }
+    .provisions-tab { padding: 6px 14px; border: 1px solid #555; background: #1a1a2e; color: #ccc; cursor: pointer; border-radius: 4px 4px 0 0; }
+    .provisions-tab.active { background: #2a2a4e; color: #fff; border-bottom-color: #2a2a4e; }
+    .provisions-content { min-height: 120px; }
+    .provisions-empty { color: #888; font-style: italic; padding: 20px; text-align: center; }
+    .provision-list { display: flex; flex-direction: column; gap: 6px; }
+    .provision-item { padding: 8px 10px; border: 1px solid #444; border-radius: 4px; cursor: pointer; transition: border-color 0.2s; }
+    .provision-item:hover { border-color: #888; }
+    .provision-item.selected { border-color: #2ecc71; background: #1a2a1a; }
+    .provision-item-header { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
+    .provision-item-name { font-weight: bold; }
+    .provision-item-rarity { font-size: 0.8em; }
+    .provision-item-qty { margin-left: auto; font-weight: bold; color: #ccc; }
+    .provision-item-desc { color: #aaa; font-size: 0.85em; margin: 2px 0; }
+    .provision-item-effect { color: #7bed9f; font-size: 0.85em; }
+    .provision-use-btn { margin-top: 6px; padding: 4px 16px; background: #2ecc71; color: #000; border: none; border-radius: 3px; cursor: pointer; font-weight: bold; }
+    .provision-use-btn:hover { background: #27ae60; }
+    .recipe-list { display: flex; flex-direction: column; gap: 8px; }
+    .recipe-card { padding: 8px 10px; border: 1px solid #444; border-radius: 4px; }
+    .recipe-card.recipe-locked { opacity: 0.6; }
+    .recipe-header { display: flex; justify-content: space-between; align-items: center; }
+    .recipe-name { font-weight: bold; color: #f0c040; }
+    .recipe-level { font-size: 0.85em; color: #aaa; }
+    .recipe-desc { color: #aaa; font-size: 0.85em; margin: 2px 0; }
+    .recipe-ingredients { font-size: 0.85em; margin: 4px 0; }
+    .recipe-ingredient.has-enough { color: #2ecc71; }
+    .recipe-ingredient.not-enough { color: #e74c3c; }
+    .recipe-result { font-size: 0.85em; color: #7bed9f; margin: 2px 0; }
+    .recipe-cook-btn { margin-top: 4px; padding: 4px 14px; background: #f0c040; color: #000; border: none; border-radius: 3px; cursor: pointer; font-weight: bold; }
+    .recipe-cook-btn:hover:not(:disabled) { background: #d4a830; }
+    .recipe-cook-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+    .buff-list { display: flex; flex-direction: column; gap: 6px; }
+    .buff-card { padding: 8px 10px; border: 1px solid #444; border-radius: 4px; background: #1a2a1a; }
+    .buff-header { display: flex; justify-content: space-between; align-items: center; }
+    .buff-name { font-weight: bold; color: #2ecc71; }
+    .buff-turns { font-size: 0.85em; color: #f0c040; }
+    .buff-effects { color: #7bed9f; font-size: 0.85em; margin-top: 2px; }
+    .provision-buffs-bar { display: flex; flex-wrap: wrap; gap: 4px; align-items: center; padding: 4px 8px; background: #1a2a1a; border-radius: 4px; margin: 4px 0; }
+    .provision-buffs-label { font-size: 0.85em; color: #2ecc71; font-weight: bold; }
+    .provision-buff-chip { font-size: 0.8em; background: #2a3a2a; border: 1px solid #2ecc71; border-radius: 12px; padding: 2px 8px; color: #7bed9f; }
+  `;
+}

--- a/tests/provisions-handler-import-test.mjs
+++ b/tests/provisions-handler-import-test.mjs
@@ -1,0 +1,190 @@
+// Import test for provisions-handler.js
+// Verifies the module loads in Node without DOM dependencies
+
+import assert from 'node:assert';
+import { handleProvisionAction, getProvisionBuffSummary } from '../src/handlers/provisions-handler.js';
+
+// 1. Exports exist
+assert.strictEqual(typeof handleProvisionAction, 'function', 'handleProvisionAction should be a function');
+assert.strictEqual(typeof getProvisionBuffSummary, 'function', 'getProvisionBuffSummary should be a function');
+
+// 2. handleProvisionAction returns null for unknown actions
+assert.strictEqual(handleProvisionAction({}, { type: 'UNKNOWN' }), null);
+assert.strictEqual(handleProvisionAction({}, null), null);
+assert.strictEqual(handleProvisionAction({}, {}), null);
+
+// 3. OPEN_PROVISIONS sets phase to 'provisions'
+const baseState = {
+  phase: 'exploration',
+  player: { level: 1, hp: 50, maxHp: 50, mp: 15, maxMp: 15, inventory: [] },
+  log: [],
+};
+const opened = handleProvisionAction(baseState, { type: 'OPEN_PROVISIONS' });
+assert.strictEqual(opened.phase, 'provisions');
+assert.strictEqual(opened.previousPhase, 'exploration');
+assert.ok(opened.provisionsUI, 'provisionsUI should be set');
+assert.strictEqual(opened.provisionsUI.tab, 'use');
+
+// 4. OPEN_PROVISIONS blocked during class-select
+const classSelectState = { ...baseState, phase: 'class-select' };
+assert.strictEqual(handleProvisionAction(classSelectState, { type: 'OPEN_PROVISIONS' }), null);
+
+// 5. CLOSE_PROVISIONS returns to previous phase
+const provisionPhaseState = { ...opened };
+const closed = handleProvisionAction(provisionPhaseState, { type: 'CLOSE_PROVISIONS' });
+assert.strictEqual(closed.phase, 'exploration');
+assert.strictEqual(closed.provisionsUI, undefined);
+
+// 6. PROVISIONS_SELECT selects a provision
+const selected = handleProvisionAction(
+  { ...opened },
+  { type: 'PROVISIONS_SELECT', provisionId: 'travelerBread' }
+);
+assert.strictEqual(selected.provisionsUI.selectedProvision, 'travelerBread');
+
+// 7. PROVISIONS_SWITCH_TAB changes tab
+const switched = handleProvisionAction(
+  { ...opened },
+  { type: 'PROVISIONS_SWITCH_TAB', tab: 'cook' }
+);
+assert.strictEqual(switched.provisionsUI.tab, 'cook');
+
+// 8. USE_PROVISION fails when not in inventory
+const useResult = handleProvisionAction(
+  { ...opened, provisionState: { activeBuffs: [], provisionsUsed: 0 } },
+  { type: 'USE_PROVISION', provisionId: 'travelerBread' }
+);
+assert.ok(useResult.provisionsUI.message, 'Should have error message');
+
+// 9. USE_PROVISION succeeds when provision is in inventory
+const stateWithProvision = {
+  ...opened,
+  player: {
+    ...baseState.player,
+    inventory: [{ id: 'travelerBread', name: "Traveler's Bread", type: 'provision', quantity: 2 }],
+  },
+  provisionState: { activeBuffs: [], provisionsUsed: 0 },
+};
+const useSuccess = handleProvisionAction(stateWithProvision, { type: 'USE_PROVISION', provisionId: 'travelerBread' });
+assert.ok(useSuccess, 'Should return updated state');
+assert.strictEqual(useSuccess.provisionState.provisionsUsed, 1);
+// Quantity should decrease
+const breadAfterUse = useSuccess.player.inventory.find(i => i.id === 'travelerBread');
+assert.ok(!breadAfterUse || breadAfterUse.quantity === 1, 'Bread quantity should decrease by 1');
+
+// 10. USE_PROVISION with instant heal
+const stateWithMushroom = {
+  ...opened,
+  player: {
+    ...baseState.player,
+    hp: 30,
+    maxHp: 50,
+    inventory: [{ id: 'fieldMushroom', name: 'Field Mushroom', type: 'provision', quantity: 1 }],
+  },
+  provisionState: { activeBuffs: [], provisionsUsed: 0 },
+};
+const healResult = handleProvisionAction(stateWithMushroom, { type: 'USE_PROVISION', provisionId: 'fieldMushroom' });
+assert.ok(healResult.player.hp > 30, 'HP should increase after using Field Mushroom');
+assert.ok(healResult.player.hp <= 50, 'HP should not exceed maxHp');
+
+// 11. TICK_PROVISIONS with no provisionState returns null
+assert.strictEqual(handleProvisionAction({}, { type: 'TICK_PROVISIONS' }), null);
+
+// 12. TICK_PROVISIONS ticks down buffs
+const stateWithBuff = {
+  ...baseState,
+  provisionState: {
+    activeBuffs: [
+      { id: 'heartyStew', name: 'Hearty Stew', turnsRemaining: 3, atkBoost: 3, defBoost: 2, hpRegen: 0, mpRegen: 0 },
+    ],
+    provisionsUsed: 1,
+  },
+};
+const ticked = handleProvisionAction(stateWithBuff, { type: 'TICK_PROVISIONS' });
+assert.ok(ticked, 'Should return updated state');
+assert.strictEqual(ticked.provisionState.activeBuffs[0].turnsRemaining, 2);
+
+// 13. TICK_PROVISIONS removes expired buffs
+const stateExpiring = {
+  ...baseState,
+  provisionState: {
+    activeBuffs: [
+      { id: 'heartyStew', name: 'Hearty Stew', turnsRemaining: 1, atkBoost: 3, defBoost: 2, hpRegen: 0, mpRegen: 0 },
+    ],
+    provisionsUsed: 1,
+  },
+};
+const expired = handleProvisionAction(stateExpiring, { type: 'TICK_PROVISIONS' });
+assert.strictEqual(expired.provisionState.activeBuffs.length, 0, 'Expired buff should be removed');
+
+// 14. COOK_PROVISION requires correct phase
+const cookOutOfPhase = handleProvisionAction(baseState, { type: 'COOK_PROVISION', recipeId: 'cookHeartyStew' });
+assert.strictEqual(cookOutOfPhase, null);
+
+// 15. COOK_PROVISION checks level requirement
+const lowLevelCook = handleProvisionAction(
+  {
+    ...opened,
+    player: { ...baseState.player, level: 1, inventory: [] },
+  },
+  { type: 'COOK_PROVISION', recipeId: 'cookHeartyStew' }
+);
+assert.ok(lowLevelCook.provisionsUI.message.includes('Requires level'));
+
+// 16. COOK_PROVISION checks missing ingredients
+const noIngredientsCook = handleProvisionAction(
+  {
+    ...opened,
+    player: { ...baseState.player, level: 5, inventory: [] },
+  },
+  { type: 'COOK_PROVISION', recipeId: 'cookHeartyStew' }
+);
+assert.ok(noIngredientsCook.provisionsUI.message.includes('Missing ingredient'));
+
+// 17. COOK_PROVISION succeeds with all ingredients
+const cookState = {
+  ...opened,
+  player: {
+    ...baseState.player,
+    level: 5,
+    inventory: [
+      { id: 'herbBundle', name: 'Herb Bundle', quantity: 3 },
+      { id: 'roastedMeat', name: 'Roasted Meat', quantity: 2 },
+    ],
+  },
+};
+const cooked = handleProvisionAction(cookState, { type: 'COOK_PROVISION', recipeId: 'cookHeartyStew' });
+assert.ok(cooked, 'Should return updated state after cooking');
+const herbAfter = cooked.player.inventory.find(i => i.id === 'herbBundle');
+assert.strictEqual(herbAfter.quantity, 1, 'herbBundle should decrease by 2');
+const meatAfter = cooked.player.inventory.find(i => i.id === 'roastedMeat');
+assert.strictEqual(meatAfter.quantity, 1, 'roastedMeat should decrease by 1');
+const stewResult = cooked.player.inventory.find(i => i.id === 'heartyStew');
+assert.ok(stewResult, 'heartyStew should be added to inventory');
+assert.strictEqual(stewResult.quantity, 1);
+
+// 18. getProvisionBuffSummary with no buffs
+const emptySummary = getProvisionBuffSummary({});
+assert.strictEqual(emptySummary.buffCount, 0);
+assert.strictEqual(emptySummary.totalAtk, 0);
+assert.strictEqual(emptySummary.totalDef, 0);
+
+// 19. getProvisionBuffSummary with active buffs
+const summaryState = {
+  provisionState: {
+    activeBuffs: [
+      { id: 'heartyStew', name: 'Hearty Stew', turnsRemaining: 3, atkBoost: 3, defBoost: 2, hpRegen: 0, mpRegen: 0 },
+      { id: 'dragonPepper', name: 'Dragon Pepper Soup', turnsRemaining: 5, atkBoost: 5, defBoost: 0, hpRegen: 0, mpRegen: 0 },
+    ],
+  },
+};
+const summary = getProvisionBuffSummary(summaryState);
+assert.strictEqual(summary.buffCount, 2);
+assert.strictEqual(summary.totalAtk, 8);
+assert.strictEqual(summary.totalDef, 2);
+assert.deepStrictEqual(summary.buffNames, ['Hearty Stew', 'Dragon Pepper Soup']);
+
+// 20. USE_PROVISION with no provisionId returns null
+assert.strictEqual(handleProvisionAction(opened, { type: 'USE_PROVISION' }), null);
+
+console.log('provisions-handler-import-test: All 20 tests passed ✅');

--- a/tests/provisions-ui-import-test.mjs
+++ b/tests/provisions-ui-import-test.mjs
@@ -1,0 +1,163 @@
+// Import test for provisions-ui.js
+// Verifies the module loads in Node without DOM dependencies (lazy DOM access)
+
+import assert from 'node:assert';
+import {
+  renderProvisionBuffs,
+  renderProvisionsPanel,
+  attachProvisionsHandlers,
+  getProvisionsStyles,
+} from '../src/provisions-ui.js';
+
+// 1. Exports exist
+assert.strictEqual(typeof renderProvisionBuffs, 'function', 'renderProvisionBuffs should be a function');
+assert.strictEqual(typeof renderProvisionsPanel, 'function', 'renderProvisionsPanel should be a function');
+assert.strictEqual(typeof attachProvisionsHandlers, 'function', 'attachProvisionsHandlers should be a function');
+assert.strictEqual(typeof getProvisionsStyles, 'function', 'getProvisionsStyles should be a function');
+
+// 2. renderProvisionBuffs with no buffs returns empty string
+const emptyBuffs = renderProvisionBuffs({});
+assert.strictEqual(emptyBuffs, '', 'Should return empty string when no buffs');
+
+// 3. renderProvisionBuffs with null state returns empty string
+const nullBuffs = renderProvisionBuffs(null);
+assert.strictEqual(nullBuffs, '', 'Should return empty string for null state');
+
+// 4. renderProvisionBuffs with active buffs returns HTML
+const stateWithBuffs = {
+  provisionState: {
+    activeBuffs: [
+      { id: 'heartyStew', name: 'Hearty Stew', turnsRemaining: 3, atkBoost: 3, defBoost: 2, hpRegen: 0, mpRegen: 0 },
+    ],
+  },
+};
+const buffsHtml = renderProvisionBuffs(stateWithBuffs);
+assert.ok(buffsHtml.includes('Hearty Stew'), 'Should include buff name');
+assert.ok(buffsHtml.includes('3t'), 'Should include turns remaining');
+assert.ok(buffsHtml.includes('provision-buffs-bar'), 'Should have buffs bar class');
+assert.ok(buffsHtml.includes('+3 ATK'), 'Should show ATK bonus in summary');
+assert.ok(buffsHtml.includes('+2 DEF'), 'Should show DEF bonus in summary');
+
+// 5. renderProvisionsPanel with minimal state
+const panelState = {
+  phase: 'provisions',
+  player: { level: 1, hp: 50, maxHp: 50, mp: 15, maxMp: 15, inventory: [] },
+  provisionsUI: { tab: 'use', selectedProvision: null, message: null },
+  log: [],
+};
+const panelHtml = renderProvisionsPanel(panelState);
+assert.ok(panelHtml.includes('Provisions'), 'Should include title');
+assert.ok(panelHtml.includes('provisions-panel'), 'Should have panel class');
+assert.ok(panelHtml.includes('btnCloseProvisions'), 'Should have close button');
+assert.ok(panelHtml.includes('no provisions'), 'Should show empty message when no provisions');
+
+// 6. renderProvisionsPanel with provisions in inventory
+const panelWithItems = {
+  ...panelState,
+  player: {
+    ...panelState.player,
+    inventory: [
+      { id: 'travelerBread', name: "Traveler's Bread", type: 'provision', quantity: 3 },
+      { id: 'herbTea', name: 'Herb Tea', type: 'provision', quantity: 1 },
+    ],
+  },
+};
+const itemsHtml = renderProvisionsPanel(panelWithItems);
+assert.ok(itemsHtml.includes("Traveler&#39;s Bread") || itemsHtml.includes("Traveler's Bread"), 'Should include bread name');
+assert.ok(itemsHtml.includes('Herb Tea'), 'Should include tea name');
+assert.ok(itemsHtml.includes('x3'), 'Should show quantity');
+
+// 7. renderProvisionsPanel cook tab
+const cookState = {
+  ...panelState,
+  provisionsUI: { tab: 'cook', selectedProvision: null, message: null },
+  player: { ...panelState.player, level: 5 },
+};
+const cookHtml = renderProvisionsPanel(cookState);
+assert.ok(cookHtml.includes('Cook Hearty Stew') || cookHtml.includes('cookHeartyStew'), 'Should include cooking recipe');
+assert.ok(cookHtml.includes('recipe-card'), 'Should have recipe card class');
+
+// 8. renderProvisionsPanel buffs tab
+const buffsTabState = {
+  ...panelState,
+  provisionsUI: { tab: 'buffs', selectedProvision: null, message: null },
+  provisionState: {
+    activeBuffs: [
+      { id: 'dragonPepper', name: 'Dragon Pepper Soup', turnsRemaining: 5, atkBoost: 5, defBoost: 0, hpRegen: 0, mpRegen: 0 },
+    ],
+  },
+};
+const buffsTabHtml = renderProvisionsPanel(buffsTabState);
+assert.ok(buffsTabHtml.includes('Dragon Pepper Soup'), 'Should include buff name');
+assert.ok(buffsTabHtml.includes('5 turns left'), 'Should show turns remaining');
+assert.ok(buffsTabHtml.includes('+5 ATK'), 'Should show ATK effect');
+
+// 9. renderProvisionsPanel message display
+const messageState = {
+  ...panelState,
+  provisionsUI: { tab: 'use', selectedProvision: null, message: 'Used Herb Tea.' },
+};
+const messageHtml = renderProvisionsPanel(messageState);
+assert.ok(messageHtml.includes('Used Herb Tea.'), 'Should display message');
+assert.ok(messageHtml.includes('provisions-message'), 'Should have message class');
+
+// 10. renderProvisionsPanel selected provision
+const selectedState = {
+  ...panelWithItems,
+  provisionsUI: { tab: 'use', selectedProvision: 'travelerBread', message: null },
+};
+const selectedHtml = renderProvisionsPanel(selectedState);
+assert.ok(selectedHtml.includes('selected'), 'Should have selected class');
+assert.ok(selectedHtml.includes('Consume'), 'Should show Consume button for selected provision');
+
+// 11. getProvisionsStyles returns CSS string
+const styles = getProvisionsStyles();
+assert.ok(typeof styles === 'string', 'Should return string');
+assert.ok(styles.includes('.provisions-panel'), 'Should include panel style');
+assert.ok(styles.includes('.provision-item'), 'Should include item style');
+assert.ok(styles.includes('.recipe-card'), 'Should include recipe card style');
+assert.ok(styles.includes('.buff-card'), 'Should include buff card style');
+assert.ok(styles.includes('.provision-buffs-bar'), 'Should include buffs bar style');
+
+// 12. attachProvisionsHandlers works without document (no-op in Node)
+attachProvisionsHandlers(() => {});
+
+// 13. XSS safety: HTML-escaped output
+const xssState = {
+  ...panelState,
+  provisionsUI: { tab: 'use', selectedProvision: null, message: '<script>alert("xss")</script>' },
+};
+const xssHtml = renderProvisionsPanel(xssState);
+assert.ok(!xssHtml.includes('<script>'), 'Should escape script tags');
+assert.ok(xssHtml.includes('&lt;script&gt;'), 'Should HTML-encode angle brackets');
+
+// 14. renderProvisionBuffs with multiple buffs shows combined summary
+const multiBuffState = {
+  provisionState: {
+    activeBuffs: [
+      { id: 'heartyStew', name: 'Hearty Stew', turnsRemaining: 3, atkBoost: 3, defBoost: 2, hpRegen: 0, mpRegen: 0 },
+      { id: 'dragonPepper', name: 'Dragon Pepper Soup', turnsRemaining: 5, atkBoost: 5, defBoost: 0, hpRegen: 0, mpRegen: 0 },
+    ],
+  },
+};
+const multiHtml = renderProvisionBuffs(multiBuffState);
+assert.ok(multiHtml.includes('+8 ATK'), 'Should show combined ATK bonus (3+5)');
+assert.ok(multiHtml.includes('+2 DEF'), 'Should show combined DEF bonus');
+assert.ok(multiHtml.includes('Hearty Stew'), 'Should list first buff');
+assert.ok(multiHtml.includes('Dragon Pepper Soup'), 'Should list second buff');
+
+// 15. Rarity colors appear in output
+const rarityState = {
+  ...panelState,
+  player: {
+    ...panelState.player,
+    inventory: [
+      { id: 'dragonPepper', name: 'Dragon Pepper Soup', type: 'provision', quantity: 1 },
+    ],
+  },
+};
+const rarityHtml = renderProvisionsPanel(rarityState);
+assert.ok(rarityHtml.includes('#3498db'), 'Should include Rare color');
+assert.ok(rarityHtml.includes('[Rare]'), 'Should show rarity label');
+
+console.log('provisions-ui-import-test: All 15 tests passed ✅');


### PR DESCRIPTION
## Provisions UI Integration

Adds the UI layer and action handler for the provisions system (merged in PR #221).

### New Files
- **src/handlers/provisions-handler.js** — Handles all provision actions:
  - `OPEN_PROVISIONS` / `CLOSE_PROVISIONS` — Phase transitions
  - `USE_PROVISION` — Consume a provision for instant effects + timed buffs
  - `TICK_PROVISIONS` — Tick down buff durations each turn
  - `COOK_PROVISION` — Cook recipes from ingredients
  - `PROVISIONS_SELECT` / `PROVISIONS_SWITCH_TAB` — UI navigation
  - `getProvisionBuffSummary()` — Summary for combat/exploration display

- **src/provisions-ui.js** — Renders the provisions panel:
  - **Use tab**: List provisions in inventory, select + consume
  - **Cook tab**: Show cooking recipes with ingredient checks
  - **Buffs tab**: Display active provision buffs with turns remaining
  - `renderProvisionBuffs()` — Compact buff bar for combat/exploration panels
  - `getProvisionsStyles()` — All CSS for the provisions UI
  - `attachProvisionsHandlers()` — Event handler attachment (lazy DOM access)

### Tests
- **tests/provisions-handler-import-test.mjs** — 20 tests covering all action types
- **tests/provisions-ui-import-test.mjs** — 15 tests covering rendering, XSS safety, styles

### Design Decisions
- Lazy DOM access pattern (no top-level window/document refs) — Node-safe for testing
- XSS-safe output via esc() helper
- Follows existing handler/UI patterns (dungeon-handler, shop-ui)
- Rarity colors: Common(grey), Uncommon(green), Rare(blue), Epic(purple)

### Next Steps (separate PR)
- Wire into render.js and ui-handler.js dispatch
- Add provisions button to exploration/combat UI
- Integrate buff ticking into combat turn cycle

Author: Claude Opus 4.6 (Villager, d6=5)