### PR TITLE
tests: provisions render/source guard + import sanity

### DIFF
--- a/tests/provisions-buffbar-source-guard-test.mjs
+++ b/tests/provisions-buffbar-source-guard-test.mjs
@@ -1,0 +1,15 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+// This is a deterministic source-guard: it ensures the provisions buff bar
+// is not only computed but also inserted into the combat HUD HTML.
+// It does NOT parse JS; it simply checks for precise substrings so it's resilient
+// to whitespace/formatting changes.
+
+test('provisions buff bar is computed and inserted into combat HUD', () => {
+  const src = readFileSync('src/render.js', 'utf8');
+  assert.match(src, /renderProvisionBuffs\(state\)/, 'renderProvisionBuffs(state) should be referenced');
+  assert.match(src, /const\s+provisionBuffBar\s*=\s*renderProvisionBuffs\(state\)/, 'provisionBuffBar should be computed');
+  assert.ok(src.includes('${provisionBuffBar}'), 'provisionBuffBar must be inserted into HUD HTML');
+});

--- a/tests/provisions-ui-render-buffs-contract-test.mjs
+++ b/tests/provisions-ui-render-buffs-contract-test.mjs
@@ -1,0 +1,15 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+// Sanity import test for provisions UI renderer. Node-only; no DOM.
+// Verifies the module exists and its primary renderer returns a string
+// when called with a minimal mock state.
+
+test('renderProvisionBuffs imports and returns a string', async () => {
+  const mod = await import('../src/provisions-ui.js');
+  assert.equal(typeof mod.renderProvisionBuffs, 'function', 'renderProvisionBuffs should be exported');
+  // Minimal state; renderer should handle missing/empty data gracefully.
+  const mockState = { inventory: {}, player: {}, provisions: {} };
+  const out = mod.renderProvisionBuffs(mockState);
+  assert.equal(typeof out, 'string', 'renderer should return a string');
+});


### PR DESCRIPTION
- Add provisions-buffbar-source-guard-test.mjs: ensures renderProvisionBuffs is computed and inserted into combat HUD
- Add provisions-ui-render-buffs-contract-test.mjs: verifies provisions-ui.js exports renderProvisionBuffs returning string
- Both tests are Node-only and deterministic regression tripwires
- Guards against regressions like the PR #233 buff bar omission issue

## Summary

(What does this PR do? Keep it small and focused.)

## Module / area

- [ ] Engine
- [ ] Combat
- [ ] Characters/Party
- [ ] Items/Equipment
- [ ] Enemies/Data
- [ ] Map/World
- [ ] UI/Renderer
- [ ] Story/Dialog
- [ ] Docs/Process
- [ ] Other: 

## Checklist

- [ ] PR is scoped (one feature / one module)
- [ ] No obfuscated/minified code
- [ ] No hidden links / tracking pixels / base64 blobs
- [ ] No large copy-pasted external assets without licensing
- [ ] If touching shared surfaces (`render.js`, state/save/load), requested 2 reviewers

## How to test

1. Open `index.html` (or serve locally if your browser blocks ES modules from `file://`).
2. 
