### PR TITLE
Add combat stats display to battle summary screen

### DIFF
--- a/src/battle-summary.js
+++ b/src/battle-summary.js
@@ -3,6 +3,8 @@
  * Displays XP gained, gold earned, items looted, and level-ups after a combat victory.
  */
 
+import { computeDerivedStats, formatCombatStatsDisplay } from './combat-stats-tracker.js';
+
 /**
  * Create a battle summary object from the victory state.
  * @param {object} state - The current game state (should be in 'victory' phase)
@@ -15,13 +17,20 @@ export function createBattleSummary(state) {
   const lootedItems = Array.isArray(state.lootedItems) ? [...state.lootedItems] : [];
   const levelUps = Array.isArray(state.pendingLevelUps) ? [...state.pendingLevelUps] : [];
 
-  return {
+  const summary = {
     xpGained,
     goldGained,
     enemyName,
     lootedItems,
     levelUps,
   };
+
+  summary.combatStats = state.combatStats ?? null;
+  summary.combatStatsDisplay = state.combatStats
+    ? formatCombatStatsDisplay(state.combatStats)
+    : null;
+
+  return summary;
 }
 
 /**
@@ -53,4 +62,89 @@ export function formatBattleSummary(summary) {
     hasLevelUps: summary.levelUps.length > 0,
     hasLoot: summary.lootedItems.length > 0,
   };
+}
+
+function escapeHtml(value) {
+  return String(value)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+export function renderCombatStatsHtml(combatStatsDisplay) {
+  if (!combatStatsDisplay || !Array.isArray(combatStatsDisplay.sections) || combatStatsDisplay.sections.length === 0) {
+    return '';
+  }
+
+  const ratingColors = {
+    S: '#d4af37',
+    A: '#4f4',
+    B: '#4af',
+    C: '#999',
+    D: '#f44',
+  };
+
+  const sectionsHtml = combatStatsDisplay.sections.map((section) => {
+    if (section?.type === 'header') {
+      const rating = escapeHtml(section.rating ?? '');
+      const title = escapeHtml(section.title ?? '');
+      const subtitle = escapeHtml(section.subtitle ?? '');
+      const color = ratingColors[section.rating] ?? '#999';
+
+      return `
+        <div style="display:flex;align-items:center;gap:12px;margin:10px 0;">
+          <div style="font-size:40px;font-weight:700;line-height:1;color:${color};min-width:36px;text-align:center;">
+            ${rating}
+          </div>
+          <div>
+            <div style="font-size:18px;font-weight:700;">${title}</div>
+            <div style="font-size:13px;opacity:0.8;">${subtitle}</div>
+          </div>
+        </div>
+      `;
+    }
+
+    if (section?.type === 'stats') {
+      const title = escapeHtml(section.title ?? '');
+      const rows = Array.isArray(section.rows) ? section.rows : [];
+      const rowsHtml = rows.map((row) => {
+        const label = escapeHtml(row.label ?? '');
+        const value = escapeHtml(row.value ?? '');
+        const style = row.style === 'good'
+          ? 'good'
+          : row.style === 'bad'
+            ? 'bad'
+            : '';
+        const valueStyle = row.style === 'good'
+          ? 'color:#4f4;'
+          : row.style === 'bad'
+            ? 'color:#f44;'
+            : '';
+
+        return `
+          <div style="display:flex;justify-content:space-between;gap:12px;padding:2px 0;">
+            <div>${label}</div>
+            <div class="${style}" style="${valueStyle}">${value}</div>
+          </div>
+        `;
+      }).join('');
+
+      return `
+        <div style="margin:12px 0;">
+          <h3 style="margin:0 0 6px 0;font-size:16px;">${title}</h3>
+          <div>${rowsHtml}</div>
+        </div>
+      `;
+    }
+
+    return '';
+  }).join('');
+
+  return `
+    <div class="combat-stats-panel" style="margin-top:12px;padding:12px;border:1px solid rgba(255,255,255,0.2);border-radius:8px;background:rgba(0,0,0,0.25);">
+      ${sectionsHtml}
+    </div>
+  `;
 }

--- a/src/render.js
+++ b/src/render.js
@@ -30,6 +30,7 @@ import { renderCompanionPanel, renderCompanionHUD, renderCompanionBadge } from '
 import { renderDungeonPanel, renderDungeonActions, attachDungeonHandlers, getDungeonStyles, shouldShowDungeonEntrance } from './dungeon-ui.js';
 import { renderProvisionsPanel, renderProvisionBuffs, attachProvisionsHandlers, getProvisionsStyles } from './provisions-ui.js';
 import { renderShieldBreakHUD } from './shield-break-ui.js';
+import { renderCombatStatsHtml } from './battle-summary.js';
 
 function hpLine(entity) {
   const pct = Math.round((entity.hp / entity.maxHp) * 100);
@@ -579,6 +580,7 @@ export function render(state, dispatch) {
           ${lootHtml}
           ${levelUpHtml ? '<h3 class="good">Level Up!</h3>' + levelUpHtml : ''}
         </div>
+        ${bs.combatStatsDisplay ? '<div class="card">' + renderCombatStatsHtml(bs.combatStatsDisplay) + '</div>' : ''}
       </div>
     `;
     actions.innerHTML = '<div class="buttons"><button id="btnContinueAfterBattle">Continue →</button></div>';

--- a/tests/battle-summary-combat-stats-test.mjs
+++ b/tests/battle-summary-combat-stats-test.mjs
@@ -1,0 +1,446 @@
+/**
+ * Tests for combat stats integration in battle-summary.js
+ * Verifies that createBattleSummary includes combatStats and combatStatsDisplay,
+ * and that renderCombatStatsHtml produces correct HTML output.
+ */
+
+import { createBattleSummary, formatBattleSummary, renderCombatStatsHtml } from '../src/battle-summary.js';
+import { createCombatStats, recordPlayerAttack, recordPlayerDefend, recordAbilityUse,
+         recordDamageReceived, recordTurn, finalizeCombatStats, formatCombatStatsDisplay } from '../src/combat-stats-tracker.js';
+
+let passed = 0;
+let failed = 0;
+
+function assert(cond, msg) {
+  if (cond) { passed++; }
+  else { failed++; console.error('FAIL:', msg); }
+}
+
+// ── createBattleSummary tests ──
+
+// Test 1: createBattleSummary without combatStats returns null fields
+{
+  const state = {
+    xpGained: 50,
+    goldGained: 25,
+    enemy: { name: 'Slime' },
+    lootedItems: [],
+    pendingLevelUps: [],
+  };
+  const summary = createBattleSummary(state);
+  assert(summary.combatStats === null, 'combatStats should be null when not present in state');
+  assert(summary.combatStatsDisplay === null, 'combatStatsDisplay should be null when not present');
+  assert(summary.xpGained === 50, 'xpGained should be preserved');
+  assert(summary.goldGained === 25, 'goldGained should be preserved');
+  assert(summary.enemyName === 'Slime', 'enemyName should be preserved');
+}
+
+// Test 2: createBattleSummary with combatStats includes display data
+{
+  let stats = createCombatStats('Goblin', false);
+  stats = recordPlayerAttack(stats, 15);
+  stats = recordTurn(stats, 'player');
+  stats = recordDamageReceived(stats, 5);
+  stats = recordTurn(stats, 'enemy');
+  stats = finalizeCombatStats(stats, 'victory', 45, 50);
+  
+  const state = {
+    xpGained: 30,
+    goldGained: 10,
+    enemy: { name: 'Goblin' },
+    lootedItems: [{ name: 'Goblin Tooth', rarity: 'Common' }],
+    pendingLevelUps: [],
+    combatStats: stats,
+  };
+  const summary = createBattleSummary(state);
+  assert(summary.combatStats !== null, 'combatStats should be present');
+  assert(summary.combatStats.enemyName === 'Goblin', 'combatStats.enemyName should be Goblin');
+  assert(summary.combatStats.totalDamageDealt === 15, 'combatStats damage dealt should be 15');
+  assert(summary.combatStats.totalDamageReceived === 5, 'combatStats damage received should be 5');
+  assert(summary.combatStatsDisplay !== null, 'combatStatsDisplay should be present');
+  assert(Array.isArray(summary.combatStatsDisplay.sections), 'combatStatsDisplay should have sections array');
+  assert(summary.combatStatsDisplay.sections.length > 0, 'combatStatsDisplay should have at least one section');
+}
+
+// Test 3: createBattleSummary preserves existing fields alongside combatStats
+{
+  let stats = createCombatStats('Dragon', true);
+  stats = finalizeCombatStats(stats, 'victory', 10, 100);
+  
+  const state = {
+    xpGained: 500,
+    goldGained: 200,
+    enemy: { name: 'Dragon' },
+    lootedItems: [{ name: 'Dragon Scale', rarity: 'Legendary' }],
+    pendingLevelUps: [{ memberName: 'Hero', newLevel: 10 }],
+    combatStats: stats,
+  };
+  const summary = createBattleSummary(state);
+  assert(summary.xpGained === 500, 'xpGained preserved with combatStats');
+  assert(summary.goldGained === 200, 'goldGained preserved with combatStats');
+  assert(summary.enemyName === 'Dragon', 'enemyName preserved with combatStats');
+  assert(summary.lootedItems.length === 1, 'lootedItems preserved');
+  assert(summary.levelUps.length === 1, 'levelUps preserved');
+  assert(summary.combatStats.isBoss === true, 'isBoss flag preserved');
+}
+
+// ── renderCombatStatsHtml tests ──
+
+// Test 4: renderCombatStatsHtml with null returns empty string
+{
+  assert(renderCombatStatsHtml(null) === '', 'null input returns empty string');
+  assert(renderCombatStatsHtml(undefined) === '', 'undefined input returns empty string');
+  assert(renderCombatStatsHtml({}) === '', 'empty object returns empty string');
+  assert(renderCombatStatsHtml({ sections: [] }) === '', 'empty sections returns empty string');
+}
+
+// Test 5: renderCombatStatsHtml with header section renders rating
+{
+  const display = {
+    sections: [
+      { type: 'header', title: 'Battle Complete!', subtitle: 'vs Slime', rating: 'S', outcome: 'victory' }
+    ]
+  };
+  const html = renderCombatStatsHtml(display);
+  assert(html.includes('combat-stats-panel'), 'contains panel class');
+  assert(html.includes('S'), 'contains S rating');
+  assert(html.includes('#d4af37'), 'S rating uses gold color');
+  assert(html.includes('Battle Complete!'), 'contains title');
+  assert(html.includes('vs Slime'), 'contains subtitle');
+}
+
+// Test 6: renderCombatStatsHtml with stats section renders rows
+{
+  const display = {
+    sections: [
+      {
+        type: 'stats',
+        title: 'Combat Overview',
+        rows: [
+          { label: 'Turns', value: '5' },
+          { label: 'Damage Dealt', value: '120', style: 'good' },
+          { label: 'Damage Received', value: '30', style: 'bad' },
+        ]
+      }
+    ]
+  };
+  const html = renderCombatStatsHtml(display);
+  assert(html.includes('Combat Overview'), 'contains section title');
+  assert(html.includes('Turns'), 'contains Turns label');
+  assert(html.includes('120'), 'contains damage dealt value');
+  assert(html.includes('color:#4f4'), 'good style has green color');
+  assert(html.includes('color:#f44'), 'bad style has red color');
+}
+
+// Test 7: renderCombatStatsHtml with A rating uses green color
+{
+  const display = {
+    sections: [
+      { type: 'header', rating: 'A', title: 'Test', subtitle: 'test' }
+    ]
+  };
+  const html = renderCombatStatsHtml(display);
+  assert(html.includes('#4f4'), 'A rating uses green');
+}
+
+// Test 8: renderCombatStatsHtml with B rating uses blue color
+{
+  const display = {
+    sections: [
+      { type: 'header', rating: 'B', title: 'Test', subtitle: 'test' }
+    ]
+  };
+  const html = renderCombatStatsHtml(display);
+  assert(html.includes('#4af'), 'B rating uses blue');
+}
+
+// Test 9: renderCombatStatsHtml with D rating uses red color
+{
+  const display = {
+    sections: [
+      { type: 'header', rating: 'D', title: 'Test', subtitle: 'test' }
+    ]
+  };
+  const html = renderCombatStatsHtml(display);
+  assert(html.includes('#f44'), 'D rating uses red');
+}
+
+// Test 10: renderCombatStatsHtml escapes HTML in user strings
+{
+  const display = {
+    sections: [
+      { type: 'header', title: '<script>alert("xss")</script>', subtitle: 'test', rating: 'C' },
+      { type: 'stats', title: 'Test', rows: [{ label: '<b>bold</b>', value: '&dangerous' }] }
+    ]
+  };
+  const html = renderCombatStatsHtml(display);
+  assert(!html.includes('<script>'), 'HTML in title is escaped');
+  assert(html.includes('&lt;script&gt;'), 'script tag properly escaped');
+  assert(html.includes('&amp;dangerous'), 'ampersand properly escaped');
+}
+
+// Test 11: Full integration - create stats, build summary, render HTML
+{
+  let stats = createCombatStats('Orc', false);
+  stats = recordPlayerAttack(stats, 20);
+  stats = recordTurn(stats, 'player');
+  stats = recordPlayerAttack(stats, 25);
+  stats = recordTurn(stats, 'player');
+  stats = recordDamageReceived(stats, 10);
+  stats = recordTurn(stats, 'enemy');
+  stats = recordPlayerDefend(stats);
+  stats = recordTurn(stats, 'player');
+  stats = recordAbilityUse(stats, 'fireball', 35, 0);
+  stats = recordTurn(stats, 'player');
+  stats = finalizeCombatStats(stats, 'victory', 40, 50);
+  
+  const state = {
+    xpGained: 100,
+    goldGained: 50,
+    enemy: { name: 'Orc' },
+    lootedItems: [],
+    pendingLevelUps: [],
+    combatStats: stats,
+  };
+  const summary = createBattleSummary(state);
+  const html = renderCombatStatsHtml(summary.combatStatsDisplay);
+  
+  assert(html.length > 0, 'full integration produces non-empty HTML');
+  assert(html.includes('combat-stats-panel'), 'full integration has panel');
+  assert(html.includes('Orc'), 'full integration shows enemy name');
+  assert(html.includes('Combat Overview'), 'full integration shows combat overview');
+  assert(html.includes('Performance'), 'full integration shows performance section');
+  assert(html.includes('Actions'), 'full integration shows actions section');
+}
+
+// Test 12: Stats section with no style attribute renders without color
+{
+  const display = {
+    sections: [
+      { type: 'stats', title: 'Test', rows: [{ label: 'HP', value: '50' }] }
+    ]
+  };
+  const html = renderCombatStatsHtml(display);
+  assert(!html.includes('color:#4f4') || html.includes('color:#4f4') === false, 'no style means no green');
+  // More precise: check the value div doesn't have a color style
+  assert(html.includes('HP'), 'label is rendered');
+  assert(html.includes('50'), 'value is rendered');
+}
+
+// Test 13: renderCombatStatsHtml with unknown section type renders empty
+{
+  const display = {
+    sections: [
+      { type: 'unknown', data: 'test' }
+    ]
+  };
+  const html = renderCombatStatsHtml(display);
+  assert(html.includes('combat-stats-panel'), 'panel still rendered');
+  assert(!html.includes('test'), 'unknown section type content not rendered');
+}
+
+// Test 14: Boss battle shows different title
+{
+  let stats = createCombatStats('Forest Guardian', true);
+  stats = finalizeCombatStats(stats, 'victory', 30, 100);
+  const display = formatCombatStatsDisplay(stats);
+  const html = renderCombatStatsHtml(display);
+  assert(html.includes('Boss Battle Complete!'), 'boss battle title shown');
+}
+
+// Test 15: Defeat outcome doesn't show victory rating
+{
+  let stats = createCombatStats('Dragon', false);
+  stats = recordDamageReceived(stats, 100);
+  stats = recordTurn(stats, 'enemy');
+  stats = finalizeCombatStats(stats, 'defeat', 0, 50);
+  const display = formatCombatStatsDisplay(stats);
+  assert(display.sections[0].outcome === 'defeat', 'outcome is defeat');
+  assert(display.sections[0].rating === '-', 'defeat rating is dash');
+}
+
+// Test 16: Fled outcome gets D rating
+{
+  let stats = createCombatStats('Dragon', false);
+  stats = recordTurn(stats, 'player');
+  stats = finalizeCombatStats(stats, 'fled', 20, 50);
+  const display = formatCombatStatsDisplay(stats);
+  assert(display.sections[0].rating === 'D', 'fled gets D rating');
+}
+
+// Test 17: renderCombatStatsHtml with C rating uses gray color
+{
+  const display = {
+    sections: [
+      { type: 'header', rating: 'C', title: 'Test', subtitle: 'test' }
+    ]
+  };
+  const html = renderCombatStatsHtml(display);
+  assert(html.includes('#999'), 'C rating uses gray');
+}
+
+// Test 18: Multiple sections all render
+{
+  const display = {
+    sections: [
+      { type: 'header', rating: 'A', title: 'Battle Complete!', subtitle: 'vs Slime' },
+      { type: 'stats', title: 'Overview', rows: [{ label: 'Turns', value: '3' }] },
+      { type: 'stats', title: 'Actions', rows: [{ label: 'Attacks', value: '2' }] },
+    ]
+  };
+  const html = renderCombatStatsHtml(display);
+  assert(html.includes('Battle Complete!'), 'header rendered');
+  assert(html.includes('Overview'), 'first stats section rendered');
+  assert(html.includes('Actions'), 'second stats section rendered');
+}
+
+// Test 19: formatBattleSummary still works (backward compatibility)
+{
+  const summary = {
+    xpGained: 50,
+    goldGained: 25,
+    enemyName: 'Slime',
+    lootedItems: [{ name: 'Slime Gel' }],
+    levelUps: [],
+  };
+  const formatted = formatBattleSummary(summary);
+  assert(formatted.title === 'Battle Won!', 'formatBattleSummary still works');
+  assert(formatted.xpLine === 'XP Gained: +50', 'xp line correct');
+  assert(formatted.hasLoot === true, 'hasLoot correct');
+}
+
+// Test 20: Empty enemy name defaults
+{
+  const state = {
+    enemy: null,
+    combatStats: null,
+  };
+  const summary = createBattleSummary(state);
+  assert(summary.enemyName === 'Unknown Enemy', 'null enemy defaults to Unknown Enemy');
+  assert(summary.combatStats === null, 'null combatStats preserved');
+}
+
+// Test 21: Shield break section appears when shields destroyed
+{
+  let stats = createCombatStats('Stone Golem', false);
+  stats.shieldsDestroyed = 3;
+  stats.timesEnemyBroken = 1;
+  stats.breakDamageDealt = 50;
+  stats = finalizeCombatStats(stats, 'victory', 40, 50);
+  const display = formatCombatStatsDisplay(stats);
+  const html = renderCombatStatsHtml(display);
+  assert(html.includes('Shield Break'), 'shield break section shown');
+  assert(html.includes('Shields Destroyed'), 'shields destroyed row shown');
+}
+
+// Test 22: Companion section appears when companion was active
+{
+  let stats = createCombatStats('Wolf', false);
+  stats.companionAbilityUses = 3;
+  stats.companionDamageDealt = 25;
+  stats.companionHealing = 10;
+  stats = finalizeCombatStats(stats, 'victory', 45, 50);
+  const display = formatCombatStatsDisplay(stats);
+  const html = renderCombatStatsHtml(display);
+  assert(html.includes('Companion'), 'companion section shown');
+}
+
+// Test 23: Status effects section appears when effects present
+{
+  let stats = createCombatStats('Cultist', false);
+  stats.statusEffectsInflicted = ['Burn', 'Poison'];
+  stats.statusEffectsReceived = ['Curse'];
+  stats = finalizeCombatStats(stats, 'victory', 30, 50);
+  const display = formatCombatStatsDisplay(stats);
+  const html = renderCombatStatsHtml(display);
+  assert(html.includes('Status Effects'), 'status effects section shown');
+  assert(html.includes('Burn'), 'inflicted effects shown');
+}
+
+// Test 24: Rating colors are inline styles (not class-based)
+{
+  const display = {
+    sections: [
+      { type: 'header', rating: 'S', title: 'Test', subtitle: 'test' }
+    ]
+  };
+  const html = renderCombatStatsHtml(display);
+  assert(html.includes('style=') && html.includes('#d4af37'), 'rating color is inline style');
+}
+
+// Test 25: Panel has proper border and background styling
+{
+  const display = {
+    sections: [
+      { type: 'header', rating: 'A', title: 'Test', subtitle: 'test' }
+    ]
+  };
+  const html = renderCombatStatsHtml(display);
+  assert(html.includes('border:1px solid'), 'panel has border');
+  assert(html.includes('border-radius:8px'), 'panel has rounded corners');
+  assert(html.includes('background:rgba(0,0,0,0.25)'), 'panel has dark background');
+}
+
+// Test 26: Row layout uses flexbox for label-value alignment
+{
+  const display = {
+    sections: [
+      { type: 'stats', title: 'Test', rows: [{ label: 'HP', value: '50' }] }
+    ]
+  };
+  const html = renderCombatStatsHtml(display);
+  assert(html.includes('display:flex'), 'rows use flexbox');
+  assert(html.includes('justify-content:space-between'), 'rows space between');
+}
+
+// Test 27: createBattleSummary with undefined combatStats
+{
+  const state = { xpGained: 10, goldGained: 5, enemy: { name: 'Bat' } };
+  // No combatStats property at all
+  const summary = createBattleSummary(state);
+  assert(summary.combatStats === null, 'missing combatStats defaults to null');
+  assert(summary.combatStatsDisplay === null, 'missing combatStats means null display');
+}
+
+// Test 28: Large damage numbers render correctly
+{
+  const display = {
+    sections: [
+      { type: 'stats', title: 'Test', rows: [{ label: 'Damage', value: '99999', style: 'good' }] }
+    ]
+  };
+  const html = renderCombatStatsHtml(display);
+  assert(html.includes('99999'), 'large numbers render');
+}
+
+// Test 29: Header with missing rating still renders
+{
+  const display = {
+    sections: [
+      { type: 'header', title: 'Test', subtitle: 'test' }
+    ]
+  };
+  const html = renderCombatStatsHtml(display);
+  assert(html.includes('Test'), 'header without rating still renders title');
+  assert(html.includes('#999'), 'missing rating defaults to gray');
+}
+
+// Test 30: Stats rows with missing style render without color override
+{
+  const display = {
+    sections: [
+      { type: 'stats', title: 'Test', rows: [{ label: 'Test', value: '42' }] }
+    ]
+  };
+  const html = renderCombatStatsHtml(display);
+  assert(html.includes('42'), 'value renders without style');
+}
+
+console.log(`\n=== Battle Summary Combat Stats Tests ===`);
+console.log(`Passed: ${passed}/${passed + failed}`);
+if (failed > 0) {
+  console.log(`Failed: ${failed}`);
+  process.exit(1);
+} else {
+  console.log('All tests passed! ✅');
+}


### PR DESCRIPTION
## Combat Stats Battle Summary Integration

Adds combat performance display to the battle summary screen so players can see detailed stats after each fight.

### Changes

**src/battle-summary.js** (+96 lines):
- Import `computeDerivedStats` and `formatCombatStatsDisplay` from combat-stats-tracker
- `createBattleSummary()` now includes `combatStats` and `combatStatsDisplay` from state
- New `renderCombatStatsHtml()` function generates inline-styled HTML for combat stats panel
- S/A/B/C/D performance rating with color coding (gold/green/blue/gray/red)
- Shows combat overview, performance metrics, actions breakdown
- Conditionally shows shield break, companion, and status effect sections
- HTML escaping for all user-provided strings

**src/render.js** (+2 lines):
- Import `renderCombatStatsHtml` from battle-summary.js
- Battle summary phase conditionally renders a third card with combat stats
- Only appears when `combatStatsDisplay` data is available (graceful degradation)

**tests/battle-summary-combat-stats-test.mjs** (79 tests):
- `createBattleSummary` with/without combatStats
- `renderCombatStatsHtml` for all section types and rating colors
- HTML escaping, edge cases, backward compatibility
- Full integration test (create stats -> build summary -> render HTML)

### Design Notes
- **Complementary to Claude Sonnet 4.6's combat-handler.js wiring PR**: This PR handles the *display* side. Once combat-handler.js records `state.combatStats` during combat, this code will automatically pick it up and render it in the battle summary.
- **Graceful degradation**: If `state.combatStats` is not set (e.g., before the recording side is wired), the battle summary renders exactly as before with no combat stats card.
- **Inline styles only**: No external CSS dependencies, works with existing dark theme.

### Easter Egg Scan
Zero egg/Easter references. Pure combat stats display functionality.