### PR TITLE
feat: add combat performance achievements

### DIFF
--- a/src/achievements.js
+++ b/src/achievements.js
@@ -35,13 +35,39 @@ function extractAchievementData(state) {
     shopPurchases: state.gameStats?.shopPurchases ?? legacy.shopPurchases,
     bossesDefeated: state.gameStats?.bossesDefeated ?? legacy.bossesDefeated,
     highestTavernStreak: state.gameStats?.highestTavernStreak ?? 0,
-    tavernBusts: state.gameStats?.tavernBusts ?? 0
+    tavernBusts: state.gameStats?.tavernBusts ?? 0,
+    lastCombatRating: state.combatStatsSummary?.sections?.[0]?.rating || null,
+    lastBattleMaxHit: state.combatStats?.maxSingleHit || 0
   };
 }
 
 // Achievement definitions
 const ACHIEVEMENTS = [
   // Combat achievements
+  {
+    id: 'flawless_execution',
+    name: 'Flawless Execution',
+    description: 'Achieve an S-Rank in combat',
+    category: 'combat',
+    condition: (data) => data.lastCombatRating === 'S',
+    getProgress: (data) => data.lastCombatRating === 'S' ? 1 : 0
+  },
+  {
+    id: 'efficiency_expert',
+    name: 'Efficiency Expert',
+    description: 'Achieve an A-Rank or higher in combat',
+    category: 'combat',
+    condition: (data) => data.lastCombatRating === 'S' || data.lastCombatRating === 'A',
+    getProgress: (data) => (data.lastCombatRating === 'S' || data.lastCombatRating === 'A') ? 1 : 0
+  },
+  {
+    id: 'overkill',
+    name: 'Overkill',
+    description: 'Deal 50 or more damage in a single hit',
+    category: 'combat',
+    condition: (data) => data.lastBattleMaxHit >= 50,
+    getProgress: (data) => Math.min(50, data.lastBattleMaxHit)
+  },
   {
     id: 'first_blood',
     name: 'First Blood',

--- a/tests/achievements-test.mjs
+++ b/tests/achievements-test.mjs
@@ -295,9 +295,9 @@ test('getAchievementsByCategory: Returns empty for invalid category', () => {
 });
 
 // === ACHIEVEMENT COUNTS ===
-test('getTotalCount: Returns 28 total achievements', () => {
+test('getTotalCount: Returns 31 total achievements', () => {
   const total = getTotalCount();
-  assert.strictEqual(total, 28, 'Should have 28 total achievements');
+  assert.strictEqual(total, 31, 'Should have 31 total achievements');
 });
 
 test('getUnlockedCount: Returns correct count', () => {
@@ -365,7 +365,7 @@ test('Integration: Multiple achievements unlock simultaneously', () => {
 
 test('getAllAchievements: Returns complete achievement list', () => {
   const all = getAllAchievements();
-  assert(all.length === 28, 'Should return all 28 achievements');
+  assert(all.length === 31, 'Should return all 31 achievements');
   assert(all.every(a => a.id && a.name && a.description), 'All should have required fields');
 });
 

--- a/tests/combat-performance-achievements-test.mjs
+++ b/tests/combat-performance-achievements-test.mjs
@@ -1,0 +1,48 @@
+import { trackAchievements, isUnlocked } from '../src/achievements.js';
+
+let passed = 0;
+let failed = 0;
+
+function assert(cond, msg) {
+  if (cond) { passed++; }
+  else { failed++; console.error('FAIL:', msg); }
+}
+
+{
+  const state = {
+    unlockedAchievements: [],
+    combatStatsSummary: { sections: [{ type: 'header', rating: 'S' }] },
+    combatStats: { maxSingleHit: 10 }
+  };
+  const next = trackAchievements(state);
+  assert(isUnlocked(next, 'flawless_execution'), 'S-Rank should unlock flawless_execution');
+  assert(isUnlocked(next, 'efficiency_expert'), 'S-Rank should unlock efficiency_expert');
+  assert(!isUnlocked(next, 'overkill'), 'Should not unlock overkill with 10 dmg');
+}
+
+{
+  const state = {
+    unlockedAchievements: [],
+    combatStatsSummary: { sections: [{ type: 'header', rating: 'A' }] },
+    combatStats: { maxSingleHit: 10 }
+  };
+  const next = trackAchievements(state);
+  assert(!isUnlocked(next, 'flawless_execution'), 'A-Rank should not unlock flawless_execution');
+  assert(isUnlocked(next, 'efficiency_expert'), 'A-Rank should unlock efficiency_expert');
+}
+
+{
+  const state = {
+    unlockedAchievements: [],
+    combatStatsSummary: { sections: [{ type: 'header', rating: 'B' }] },
+    combatStats: { maxSingleHit: 55 }
+  };
+  const next = trackAchievements(state);
+  assert(!isUnlocked(next, 'flawless_execution'), 'B-Rank should not unlock flawless_execution');
+  assert(!isUnlocked(next, 'efficiency_expert'), 'B-Rank should not unlock efficiency_expert');
+  assert(isUnlocked(next, 'overkill'), '55 max hit should unlock overkill');
+}
+
+console.log(`\n=== Combat Performance Achievements Tests ===`);
+console.log(`Passed: ${passed}/${passed + failed}`);
+if (failed > 0) process.exit(1);


### PR DESCRIPTION
Adds 3 new achievements for combat performance (Flawless Execution, Efficiency Expert, Overkill) tied to the newly merged combat stats tracker. Clean of eggs, fully tested.