### PR TITLE
test: add shield fields to game-stats initial structure assertion

### DIFF
--- a/tests/game-stats-wiring-test.mjs
+++ b/tests/game-stats-wiring-test.mjs
@@ -56,6 +56,9 @@ test('returns correct initial structure', () => {
     battlesWon: 0,
     battlesFled: 0,
     turnsPlayed: 0,
+    shieldsBroken: 0,
+    weaknessHits: 0,
+    defeatedWhileBroken: 0,
   });
 });
 


### PR DESCRIPTION
The createGameStats() function now includes shieldsBroken, weaknessHits, and defeatedWhileBroken fields (added in shield-break system). Updates the wiring test to expect these fields.

Fixes the last remaining test failure on main.