### PR TITLE
feat: add gradient button styles with theme integration

### DIFF
--- a/src/data/themes.js
+++ b/src/data/themes.js
@@ -15,6 +15,8 @@ export const THEMES = {
       accent: '#7aa2ff',
       bad: '#ff6b6b',
       good: '#57d38c',
+      gradientStart: '#4a6cf7',
+      gradientEnd: '#7aa2ff',
     },
   },
   forest: {
@@ -28,6 +30,8 @@ export const THEMES = {
       accent: '#7aff7a',
       bad: '#ff6b6b',
       good: '#57d38c',
+      gradientStart: '#2d8a4e',
+      gradientEnd: '#7aff7a',
     },
   },
   crimson: {
@@ -41,6 +45,8 @@ export const THEMES = {
       accent: '#ff7a7a',
       bad: '#ff6b6b',
       good: '#57d38c',
+      gradientStart: '#c44a4a',
+      gradientEnd: '#ff7a7a',
     },
   },
   ocean: {
@@ -54,6 +60,8 @@ export const THEMES = {
       accent: '#7affff',
       bad: '#ff6b6b',
       good: '#57d38c',
+      gradientStart: '#2a7a8a',
+      gradientEnd: '#7affff',
     },
   },
   light: {
@@ -67,6 +75,8 @@ export const THEMES = {
       accent: '#3366cc',
       bad: '#cc3333',
       good: '#339944',
+      gradientStart: '#4488dd',
+      gradientEnd: '#3366cc',
     },
   },
 };
@@ -83,7 +93,9 @@ export function applyTheme(themeId) {
   const root = document.documentElement;
   
   for (const [key, value] of Object.entries(theme.colors)) {
-    root.style.setProperty(`--${key}`, value);
+    // Convert camelCase to kebab-case for CSS variables
+    const cssKey = key.replace(/([A-Z])/g, '-$1').toLowerCase();
+    root.style.setProperty(`--${cssKey}`, value);
   }
 }
 

--- a/styles.css
+++ b/styles.css
@@ -217,3 +217,57 @@ button:disabled { opacity: 0.45; cursor: not-allowed; }
   width: 1.2em;
   text-align: center;
 }
+
+/* Gradient Button Styles */
+button.gradient,
+.btn-gradient {
+  appearance: none;
+  background: linear-gradient(135deg, var(--gradient-start, var(--accent)), var(--gradient-end, var(--panel)));
+  border: 1px solid rgba(255,255,255,0.2);
+  color: var(--text);
+  padding: 10px 16px;
+  border-radius: 10px;
+  cursor: pointer;
+  font-weight: 600;
+  transition: all 0.2s ease;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.2);
+}
+
+button.gradient:hover,
+.btn-gradient:hover {
+  filter: brightness(1.15);
+  box-shadow: 0 4px 12px rgba(0,0,0,0.3);
+  transform: translateY(-1px);
+}
+
+button.gradient:active,
+.btn-gradient:active {
+  filter: brightness(0.95);
+  transform: translateY(1px);
+  box-shadow: 0 1px 4px rgba(0,0,0,0.2);
+}
+
+button.gradient:disabled,
+.btn-gradient:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  filter: saturate(0.5);
+  transform: none;
+  box-shadow: none;
+}
+
+/* Gradient button variants */
+button.gradient-success,
+.btn-gradient-success {
+  background: linear-gradient(135deg, #2d8a4e, var(--good, #57d38c));
+}
+
+button.gradient-danger,
+.btn-gradient-danger {
+  background: linear-gradient(135deg, #c44a4a, var(--bad, #ff6b6b));
+}
+
+button.gradient-primary,
+.btn-gradient-primary {
+  background: linear-gradient(135deg, var(--gradient-start, #4a6cf7), var(--gradient-end, var(--accent)));
+}

--- a/tests/gradient-buttons-test.mjs
+++ b/tests/gradient-buttons-test.mjs
@@ -1,0 +1,122 @@
+/**
+ * Tests for gradient button theme integration
+ */
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { THEMES, DEFAULT_THEME, applyTheme, getThemeList } from '../src/data/themes.js';
+
+describe('Gradient Button Theme Integration', () => {
+  describe('Theme gradient colors', () => {
+    it('all themes have gradientStart color', () => {
+      for (const [themeId, theme] of Object.entries(THEMES)) {
+        assert.ok(
+          theme.colors.gradientStart,
+          `Theme "${themeId}" should have gradientStart color`
+        );
+        assert.match(
+          theme.colors.gradientStart,
+          /^#[0-9a-fA-F]{6}$/,
+          `Theme "${themeId}" gradientStart should be valid hex color`
+        );
+      }
+    });
+
+    it('all themes have gradientEnd color', () => {
+      for (const [themeId, theme] of Object.entries(THEMES)) {
+        assert.ok(
+          theme.colors.gradientEnd,
+          `Theme "${themeId}" should have gradientEnd color`
+        );
+        assert.match(
+          theme.colors.gradientEnd,
+          /^#[0-9a-fA-F]{6}$/,
+          `Theme "${themeId}" gradientEnd should be valid hex color`
+        );
+      }
+    });
+
+    it('gradient colors are distinct from each other', () => {
+      for (const [themeId, theme] of Object.entries(THEMES)) {
+        assert.notStrictEqual(
+          theme.colors.gradientStart,
+          theme.colors.gradientEnd,
+          `Theme "${themeId}" should have distinct gradient start and end colors`
+        );
+      }
+    });
+  });
+
+  describe('applyTheme function', () => {
+    it('handles missing document gracefully', () => {
+      // Should not throw when document is undefined (Node.js environment)
+      assert.doesNotThrow(() => {
+        applyTheme('midnight');
+      });
+    });
+
+    it('handles invalid theme ID gracefully', () => {
+      assert.doesNotThrow(() => {
+        applyTheme('nonexistent-theme');
+      });
+    });
+  });
+
+  describe('getThemeList function', () => {
+    it('returns array of theme objects', () => {
+      const list = getThemeList();
+      assert.ok(Array.isArray(list), 'getThemeList should return an array');
+      assert.ok(list.length > 0, 'Theme list should not be empty');
+    });
+
+    it('each theme has id and name properties', () => {
+      const list = getThemeList();
+      for (const theme of list) {
+        assert.ok(theme.id, 'Theme should have id property');
+        assert.ok(theme.name, 'Theme should have name property');
+        assert.strictEqual(typeof theme.id, 'string');
+        assert.strictEqual(typeof theme.name, 'string');
+      }
+    });
+
+    it('includes all 5 themes', () => {
+      const list = getThemeList();
+      assert.strictEqual(list.length, 5, 'Should have exactly 5 themes');
+      
+      const ids = list.map(t => t.id);
+      assert.ok(ids.includes('midnight'), 'Should include midnight theme');
+      assert.ok(ids.includes('forest'), 'Should include forest theme');
+      assert.ok(ids.includes('crimson'), 'Should include crimson theme');
+      assert.ok(ids.includes('ocean'), 'Should include ocean theme');
+      assert.ok(ids.includes('light'), 'Should include light theme');
+    });
+  });
+
+  describe('Theme color integrity', () => {
+    it('midnight theme has blue gradient', () => {
+      assert.strictEqual(THEMES.midnight.colors.gradientStart, '#4a6cf7');
+      assert.strictEqual(THEMES.midnight.colors.gradientEnd, '#7aa2ff');
+    });
+
+    it('forest theme has green gradient', () => {
+      assert.strictEqual(THEMES.forest.colors.gradientStart, '#2d8a4e');
+      assert.strictEqual(THEMES.forest.colors.gradientEnd, '#7aff7a');
+    });
+
+    it('crimson theme has red gradient', () => {
+      assert.strictEqual(THEMES.crimson.colors.gradientStart, '#c44a4a');
+      assert.strictEqual(THEMES.crimson.colors.gradientEnd, '#ff7a7a');
+    });
+
+    it('ocean theme has cyan gradient', () => {
+      assert.strictEqual(THEMES.ocean.colors.gradientStart, '#2a7a8a');
+      assert.strictEqual(THEMES.ocean.colors.gradientEnd, '#7affff');
+    });
+
+    it('light theme has blue gradient for visibility', () => {
+      assert.strictEqual(THEMES.light.colors.gradientStart, '#4488dd');
+      assert.strictEqual(THEMES.light.colors.gradientEnd, '#3366cc');
+    });
+  });
+});
+
+console.log('Running gradient buttons tests...');


### PR DESCRIPTION
## Summary
Adds gradient button styles that integrate with the new UI theme system (PR #280).

## Changes
- **src/data/themes.js**: Added `gradientStart` and `gradientEnd` colors to all 5 themes
- **styles.css**: Added gradient button CSS classes with full state support
- **tests/gradient-buttons-test.mjs**: 13 new tests for theme gradient integration

## Gradient Button Classes
- `.gradient` / `.btn-gradient` - Primary gradient using theme colors
- `.gradient-success` / `.btn-gradient-success` - Green gradient for positive actions
- `.gradient-danger` / `.btn-gradient-danger` - Red gradient for destructive actions
- `.gradient-primary` / `.btn-gradient-primary` - Theme accent gradient

## Features
- Smooth hover effects (brightness, shadow, translate)
- Active/pressed state feedback
- Disabled state with reduced saturation
- Theme-aware: gradients automatically update when theme changes

## Theme Gradient Colors
| Theme | Start | End |
|-------|-------|-----|
| Midnight | #4a6cf7 (blue) | #7aa2ff |
| Forest | #2d8a4e (green) | #7aff7a |
| Crimson | #c44a4a (red) | #ff7a7a |
| Ocean | #2a7a8a (cyan) | #7affff |
| Light | #4488dd (blue) | #3366cc |

## Testing
- All 13 new tests pass
- No easter egg patterns detected (security scan clean)

## Related
- Builds on PR #280 (UI Theme System)
- Addresses gradient button request from Issue #147