### PR TITLE
feat: add equipment comparison tooltips in inventory

### DIFF
--- a/src/inventory.js
+++ b/src/inventory.js
@@ -287,6 +287,49 @@ export function getEquipmentDisplay(equipment) {
   return display;
 }
 
+
+/**
+ * Compare a candidate equippable item against the currently equipped item in the same slot.
+ * Returns an array of { stat, current, candidate, diff } objects for all relevant stats.
+ * @param {object} equipment - player.equipment { weapon, armor, accessory }
+ * @param {string} candidateItemId - the item ID to compare
+ * @returns {{ slot: string, comparisons: Array<{stat: string, current: number, candidate: number, diff: number}> } | null}
+ */
+export function getEquipmentComparison(equipment, candidateItemId) {
+  const candidateItem = items[candidateItemId];
+  if (!candidateItem) return null;
+  const slot = TYPE_TO_SLOT[candidateItem.type];
+  if (!slot) return null;
+
+  const currentItemId = equipment ? equipment[slot] : null;
+  const currentItem = currentItemId ? items[currentItemId] : null;
+
+  const allStats = new Set();
+  const candidateStats = candidateItem.stats || {};
+  const currentStats = currentItem ? (currentItem.stats || {}) : {};
+
+  for (const s of Object.keys(candidateStats)) allStats.add(s);
+  for (const s of Object.keys(currentStats)) allStats.add(s);
+
+  const comparisons = [];
+  for (const stat of allStats) {
+    const currentVal = typeof currentStats[stat] === 'number' ? currentStats[stat] : 0;
+    const candidateVal = typeof candidateStats[stat] === 'number' ? candidateStats[stat] : 0;
+    comparisons.push({
+      stat,
+      current: currentVal,
+      candidate: candidateVal,
+      diff: candidateVal - currentVal,
+    });
+  }
+
+  return {
+    slot,
+    currentItemName: currentItem ? currentItem.name : null,
+    comparisons,
+  };
+}
+
 // --- Inventory sub-screens for the INVENTORY phase ---
 
 export const INVENTORY_SCREENS = {

--- a/src/render.js
+++ b/src/render.js
@@ -2,7 +2,7 @@ import { renderTavernDicePanel } from './tavern-dice-ui.js';
 import { saveToLocalStorage } from './state.js';
 import { CLASS_DEFINITIONS } from './characters/classes.js';
 import { DEFAULT_WORLD_DATA, getRoomExits } from './map.js';
-import { getCategorizedInventory, getEquipmentDisplay, getItemDetails, INVENTORY_SCREENS, EQUIPMENT_SLOTS, getEquipmentBonuses } from './inventory.js';
+import { getCategorizedInventory, getEquipmentDisplay, getItemDetails, getEquipmentComparison, INVENTORY_SCREENS, EQUIPMENT_SLOTS, getEquipmentBonuses } from './inventory.js';
 import { getEffectiveCombatStats, getEquipmentBonusDisplay, hasEquipmentBonuses } from './combat/equipment-bonuses.js';
 import { getCurrentLevelUp, getStatDiffs, formatStatName, xpForNextLevel } from './level-up.js';
 import { formatAbilityName } from './specialization-ui.js';
@@ -930,7 +930,24 @@ if (state.phase === 'achievements') {
     const itemRows = allItems.length === 0 ? '<div class="kv"><div><i>Empty</i></div><div></div></div>' :
       '<div class="kv">' + allItems.map(({ id, name, count, type, equippable, usable, rarity }) => {
         const useBtn = usable ? `<button class="inv-btn" data-action="use" data-item="${esc(id)}">Use</button>` : '';
-        const eqBtn = equippable ? `<button class="inv-btn" data-action="equip" data-item="${esc(id)}">Equip</button>` : '';
+        let eqBtn = '';
+        let comparisonHtml = '';
+        if (equippable) {
+          eqBtn = `<button class="inv-btn" data-action="equip" data-item="${esc(id)}">Equip</button>`;
+          const comp = getEquipmentComparison(equipment, id);
+          if (comp && comp.comparisons.length > 0) {
+            const deltas = comp.comparisons
+              .filter(c => c.diff !== 0)
+              .map(c => {
+                const sign = c.diff > 0 ? '+' : '';
+                const color = c.diff > 0 ? '#4f4' : '#f44';
+                const arrow = c.diff > 0 ? '\u2191' : '\u2193';
+                const label = c.stat.charAt(0).toUpperCase() + c.stat.slice(1);
+                return `<span style="color:${color};font-size:0.8em;margin-left:4px;" title="${label}: ${c.current} → ${c.candidate}">${sign}${c.diff} ${label} ${arrow}</span>`;
+              }).join(' ');
+            comparisonHtml = deltas || '<span style="color:#aaa;font-size:0.8em;margin-left:4px;">= same stats</span>';
+          }
+        }
         const detBtn = `<button class="inv-btn" data-action="details" data-item="${esc(id)}">Info</button>`;
         const rarityKey = typeof rarity === 'string' ? rarity : null;
         const rarityColor = rarityKey && rarityColors[rarityKey] ? rarityColors[rarityKey] : '#aaa';
@@ -949,7 +966,7 @@ if (state.phase === 'achievements') {
         const nameStyle = 'color: ' + rarityColor + ';' + (isBold ? ' font-weight: bold;' : '');
         const badgeStyle = 'color: ' + rarityColor + '; font-size: 0.8em; opacity: 0.85; margin-left: 4px;';
         const rarityTag = rarityBadge ? ` <span style="${badgeStyle}">${esc(rarityBadge)}</span>` : '';
-        return `<div>${rarityEmoji} <span style="${nameStyle}">${esc(name)}</span> <small style="color:#aaa;">(${esc(type)})</small>${rarityTag}</div><div><b>${count}</b> ${useBtn}${eqBtn}${detBtn}</div>`;
+        return `<div>${rarityEmoji} <span style="${nameStyle}">${esc(name)}</span> <small style="color:#aaa;">(${esc(type)})</small>${rarityTag}</div><div><b>${count}</b> ${useBtn}${eqBtn}${detBtn}${comparisonHtml}</div>`;
       }).join('') + '</div>';
 
     // Item details screen
@@ -976,6 +993,24 @@ if (state.phase === 'achievements') {
             <div class="buttons"><button id="btnInvBack">Back</button></div>
           </div>
         `;
+        // Add equipment comparison in details view
+        const detailComp = getEquipmentComparison(equipment, invState.selectedItem);
+        if (detailComp && detailComp.comparisons.length > 0) {
+          const vsName = detailComp.currentItemName ? esc(detailComp.currentItemName) : '<i>nothing</i>';
+          const compRows = detailComp.comparisons.map(c => {
+            const sign = c.diff > 0 ? '+' : '';
+            const color = c.diff > 0 ? '#4f4' : c.diff < 0 ? '#f44' : '#aaa';
+            const arrow = c.diff > 0 ? ' \u2191' : c.diff < 0 ? ' \u2193' : '';
+            const label = c.stat.charAt(0).toUpperCase() + c.stat.slice(1);
+            return `<div>${esc(label)}</div><div style="color:${color};"><b>${sign}${c.diff}${arrow}</b> <small>(${c.current} → ${c.candidate})</small></div>`;
+          }).join('');
+          detailsHtml += `
+            <div class="card" style="margin-top:8px;">
+              <h3 style="color:#ccc;">Compared to: ${vsName} <small style="color:#888;">(${esc(detailComp.slot)})</small></h3>
+              <div class="kv">${compRows}</div>
+            </div>
+          `;
+        }
       }
     }
 

--- a/tests/equipment-comparison-test.mjs
+++ b/tests/equipment-comparison-test.mjs
@@ -1,0 +1,116 @@
+// Equipment Comparison Tests
+// Tests for getEquipmentComparison() in src/inventory.js
+// Created by Claude Opus 4.6 (Day 344)
+
+import { getEquipmentComparison } from '../src/inventory.js';
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition, msg) {
+  if (condition) {
+    passed++;
+  } else {
+    failed++;
+    console.error(`  FAIL: ${msg}`);
+  }
+}
+
+function test(name, fn) {
+  try {
+    fn();
+  } catch (e) {
+    failed++;
+    console.error(`  FAIL: ${name} - ${e.message}`);
+  }
+}
+
+console.log('=== Equipment Comparison Tests ===');
+
+test('returns null for invalid item', () => {
+  const result = getEquipmentComparison({ weapon: null, armor: null, accessory: null }, 'nonexistent_item_xyz');
+  assert(result === null, 'should return null for invalid item');
+});
+
+test('returns null for non-equippable item (consumable)', () => {
+  const result = getEquipmentComparison({ weapon: null, armor: null, accessory: null }, 'healthPotion');
+  assert(result === null, 'should return null for consumable items');
+});
+
+test('compares weapon against empty slot', () => {
+  const equipment = { weapon: null, armor: null, accessory: null };
+  const result = getEquipmentComparison(equipment, 'rustySword');
+  assert(result !== null, 'should return comparison object');
+  assert(result.slot === 'weapon', 'slot should be weapon');
+  assert(result.currentItemName === null, 'currentItemName should be null when nothing equipped');
+  assert(Array.isArray(result.comparisons), 'comparisons should be an array');
+  const atkComp = result.comparisons.find(c => c.stat === 'attack');
+  assert(atkComp !== undefined, 'should have attack comparison');
+  assert(atkComp.current === 0, 'current attack should be 0 when nothing equipped');
+  assert(atkComp.candidate === 5, 'candidate attack should be 5 for Rusty Sword');
+  assert(atkComp.diff === 5, 'diff should be +5 attack');
+});
+
+test('compares weapon against equipped weapon (upgrade)', () => {
+  const equipment = { weapon: 'rustySword', armor: null, accessory: null };
+  const result = getEquipmentComparison(equipment, 'ironSword');
+  assert(result !== null, 'should return comparison object');
+  assert(result.slot === 'weapon', 'slot should be weapon');
+  assert(result.currentItemName === 'Rusty Sword', 'should show current item name');
+  const atkComp = result.comparisons.find(c => c.stat === 'attack');
+  assert(atkComp !== undefined, 'should have attack comparison');
+  assert(atkComp.current === 5, 'current attack should be 5');
+  assert(atkComp.candidate === 12, 'candidate attack should be 12');
+  assert(atkComp.diff === 7, 'diff should be +7 attack');
+});
+
+test('compares weapon against equipped weapon (downgrade)', () => {
+  const equipment = { weapon: 'ironSword', armor: null, accessory: null };
+  const result = getEquipmentComparison(equipment, 'rustySword');
+  assert(result !== null, 'should return comparison object');
+  const atkComp = result.comparisons.find(c => c.stat === 'attack');
+  assert(atkComp.diff === -7, 'diff should be -7 attack for downgrade');
+});
+
+test('handles stats present on one item but not the other', () => {
+  // huntersBow has attack, speed, critChance; rustySword has attack, critChance
+  const equipment = { weapon: 'rustySword', armor: null, accessory: null };
+  const result = getEquipmentComparison(equipment, 'huntersBow');
+  assert(result !== null, 'should return comparison');
+  const speedComp = result.comparisons.find(c => c.stat === 'speed');
+  assert(speedComp !== undefined, 'should include speed stat even if only on one item');
+  assert(speedComp.current === 0, 'current speed should be 0 (rustySword has no speed)');
+  assert(speedComp.candidate === 3, 'candidate speed should be 3');
+  assert(speedComp.diff === 3, 'diff should be +3 speed');
+});
+
+test('compares armor items', () => {
+  const equipment = { weapon: null, armor: 'leatherArmor', accessory: null };
+  const result = getEquipmentComparison(equipment, 'chainmail');
+  assert(result !== null, 'should return comparison');
+  assert(result.slot === 'armor', 'slot should be armor');
+  assert(result.currentItemName === 'Leather Armor', 'should show Leather Armor as current');
+  const defComp = result.comparisons.find(c => c.stat === 'defense');
+  assert(defComp !== undefined, 'should have defense comparison');
+  assert(defComp.diff > 0, 'chainmail should be better defense than leather');
+});
+
+test('compares same item against itself', () => {
+  const equipment = { weapon: 'rustySword', armor: null, accessory: null };
+  const result = getEquipmentComparison(equipment, 'rustySword');
+  assert(result !== null, 'should return comparison');
+  const allZero = result.comparisons.every(c => c.diff === 0);
+  assert(allZero, 'all diffs should be 0 when comparing same item');
+});
+
+test('handles null equipment object', () => {
+  const result = getEquipmentComparison(null, 'rustySword');
+  assert(result !== null, 'should handle null equipment');
+  assert(result.currentItemName === null, 'currentItemName should be null');
+  const atkComp = result.comparisons.find(c => c.stat === 'attack');
+  assert(atkComp.current === 0, 'current should be 0 with null equipment');
+  assert(atkComp.candidate === 5, 'candidate should be 5 for Rusty Sword');
+});
+
+console.log(`\nResults: ${passed} passed, ${failed} failed out of ${passed + failed}`);
+if (failed > 0) process.exit(1);


### PR DESCRIPTION
## Equipment Comparison Tooltips

When viewing equippable items in the inventory, players now see colored stat deltas comparing the item against their currently equipped item in the same slot.

### Changes

**src/inventory.js:**
- New `getEquipmentComparison(equipment, candidateItemId)` function
- Returns stat-by-stat comparison (current value, candidate value, diff) for all relevant stats
- Handles empty slots, null equipment, and items with different stat sets

**src/render.js:**
- **Item list**: Shows inline colored deltas next to each Equip button
  - Green "+N Stat ↑" for upgrades
  - Red "-N Stat ↓" for downgrades
  - Hover tooltip shows "Stat: current → candidate"
- **Item details screen**: Adds a full comparison card below item info
  - Shows "Compared to: [current item name] (slot)"
  - Each stat row colored green/red/gray with (current → candidate) detail

**tests/equipment-comparison-test.mjs:**
- 35 tests covering: invalid items, non-equippable items, empty slot comparison, upgrade/downgrade, cross-stat coverage, same-item comparison, null equipment, armor slot

### Screenshots
Players see at a glance whether an item is an upgrade:
- "+7 Attack ↑ +2 CritChance ↑" in green next to Equip button
- Full comparison card in item details view

All existing tests pass.