### PR TITLE
Wire battle log into combat.js

### DIFF
--- a/src/combat.js
+++ b/src/combat.js
@@ -28,6 +28,7 @@ import {
   autoReviveCompanionsAfterCombat,
 } from './companion-combat.js';
 import { getEnemyShieldData, checkWeakness, applyShieldDamage, processBreakState, BREAK_DAMAGE_MULTIPLIER } from './shield-break.js';
+import { initCombatBattleLog, logPlayerAttack, logDamageReceived, logHealing, logItemUsed, logStatusApplied, logTurnStart, logVictory, logDefeat } from './combat-battle-log-integration.js';
 
 // Minimal deterministic RNG (Park-Miller LCG)
 export function nextRng(seed) {
@@ -191,6 +192,7 @@ function applyVictoryDefeat(state) {
         state = pushLog(state, `Loot: ${loot.name} (${loot.rarity})`);
       }
     }
+    logVictory(state.enemy.name, xpGained, goldGained);
     state = pushLog(state, `Victory! The ${state.enemy.name} dissolves.`);
     // Log to journal
     state = logCombatVictory(state, state.enemy.name, goldGained, xpGained);
@@ -203,6 +205,7 @@ function applyVictoryDefeat(state) {
   }
   if (state.player.hp <= 0) {
     state = { ...state, phase: 'defeat' };
+    logDefeat();
     state = pushLog(state, `Defeat... You collapse.`);
     // Companion defeat penalty: all companions lose loyalty
     state = processCompanionDefeatPenalty(state);
@@ -239,6 +242,7 @@ export function startNewEncounter(state, zoneLevel = 1) {
   next = { ...next, currentEnemyId: enemyId, bestiary: recordEncounter(next.bestiary || { encountered: [], defeatedCounts: {} }, enemyId) };
 
   next = pushLog(next, `A wild ${enemy.name} appears.`);
+  initCombatBattleLog();
   next = pushLog(next, `Your turn.`);
   return next;
 }
@@ -297,6 +301,7 @@ export function playerAttack(state) {
   };
 
   state = pushLog(state, `You strike for ${damage} damage.`);
+  logPlayerAttack(damage, state.enemy.name);
 
   // Apply weapon on-hit status effect (e.g., freeze, bleed, blind)
   if (state.enemy.hp > 0) {
@@ -717,6 +722,7 @@ export function enemyAct(state) {
       };
 
       state = pushLog(state, `${state.enemy.name} slams you for ${damage} damage.`);
+      logDamageReceived(damage, state.enemy.name);
     }
     state = applyVictoryDefeat(state);
   }


### PR DESCRIPTION
## Summary
Integrates the battle log system (PR #290) and integration helpers (PR #293) into the core combat flow in combat.js.

## Changes
- Import battle log integration helpers from `combat-battle-log-integration.js`
- Add `initCombatBattleLog()` call in `startNewEncounter()` to initialize log for each fight
- Add `logPlayerAttack()` call in `playerAttack()` to record player attacks
- Add `logDamageReceived()` call in `enemyAct()` to record damage taken from enemies
- Add `logVictory()` call in `applyVictoryDefeat()` to record victory with XP/gold rewards
- Add `logDefeat()` call in `applyVictoryDefeat()` to record defeats

## Testing
All 42 related tests pass:
```
node --test tests/combat-test.mjs tests/battle-log-test.mjs tests/combat-battle-log-integration-test.mjs
# tests 42
# pass 42
# fail 0
```

## Next Steps
- Add battle log UI panel to render.js to display the log during combat
- Add more logging hooks (abilities, items, status effects, healing) for comprehensive combat tracking