### PR TITLE
feat: Battle log UI panel in combat screen

### DIFF
--- a/src/render.js
+++ b/src/render.js
@@ -33,6 +33,8 @@ import { renderShieldBreakHUD } from './shield-break-ui.js';
 import { renderCombatStatsHtml } from './battle-summary.js';
 import { formatLogEntryHtml, getLogStyles } from './combat-log-formatter.js';
 import { triggerFloatingTextFromLog, getFloatingTextStyles } from './floating-text.js';
+import { renderBattleLogPanel, getBattleLogStyles } from './battle-log-ui.js';
+import { getBattleLogEntries } from './combat-battle-log-integration.js';
 import { filterAndSortItems, renderSortFilterControls, SORT_MODES, FILTER_MODES } from './inventory-sort-filter.js';
 
 /** Track previous log for floating text diff */
@@ -244,6 +246,13 @@ export function render(state, dispatch) {
     ftStyleEl.id = 'floating-text-styles';
     ftStyleEl.textContent = getFloatingTextStyles();
     document.head.appendChild(ftStyleEl);
+  }
+
+  if (!document.getElementById('battle-log-styles')) {
+    const blStyleEl = document.createElement('style');
+    blStyleEl.id = 'battle-log-styles';
+    blStyleEl.textContent = getBattleLogStyles();
+    document.head.appendChild(blStyleEl);
   }
 
   const finalizeRender = () => {
@@ -465,6 +474,7 @@ export function render(state, dispatch) {
         ${renderCompanionHUD(state)}
       </div>
       ${provisionBuffBar}
+      ${renderBattleLogPanel(getBattleLogEntries(), 8)}
     `;
 
     const isPlayerTurn = state.phase === 'player-turn';


### PR DESCRIPTION
## Summary
Adds the battle log UI panel to the combat screen so players can see a play-by-play log of combat events during fights.

## Changes
- Import `renderBattleLogPanel` and `getBattleLogStyles` from `battle-log-ui.js`
- Import `getBattleLogEntries` from `combat-battle-log-integration.js`
- Inject battle log styles on render initialization
- Display battle log panel during combat phases (player-turn, enemy-turn)

## Features
- Shows last 8 combat events with type-specific icons (⚔️🔥💚💔 etc.)
- Turn tracking with header showing current turn number
- Scrollable list for longer battles
- Styled consistently with game's dark theme

## Testing
- Battle log tests pass (17 tests)
- Smoke tests pass
- Syntax check passes

This completes the battle log UI integration started in PRs #290 (battle log system), #293 (integration helpers), and #296 (combat.js wiring).