### PR TITLE
feat: Tutorial/help system with contextual hints

### DIFF
--- a/src/handlers/ui-handler.js
+++ b/src/handlers/ui-handler.js
@@ -20,6 +20,7 @@ import { shouldShowSpecialization, createSpecializationState, applySpecializatio
 import { clearFloor as clearDungeonFloor } from '../dungeon-floors.js';
 import { handleProvisionAction } from './provisions-handler.js';
 import { BESTIARY_FILTER_DEFAULT, BESTIARY_SORT_DEFAULT } from '../bestiary-ui.js';
+import { completeTutorialStep, dismissCurrentHint, showHint, createTutorialState } from '../tutorial.js';
 
 function getRoomDescription(worldState) {
   const room = getCurrentRoom(worldState);
@@ -544,6 +545,37 @@ export function handleUIAction(state, action) {
     next = pushLog(next, 'New abilities and stat bonuses have been applied.');
     next = pushLog(next, `${getRoomDescription(state.world)} Exits: ${exits.join(', ') || 'none'}.`);
     return next;
+  }
+
+  if (action.type === 'TUTORIAL_SHOW') {
+    if (!state.tutorialState) return null;
+    return {
+      ...state,
+      tutorialState: showHint(state.tutorialState, action.stepId),
+    };
+  }
+
+  if (action.type === 'TUTORIAL_DISMISS') {
+    if (!state.tutorialState || !state.tutorialState.currentHint) return null;
+    const stepId = state.tutorialState.currentHint.id;
+    return {
+      ...state,
+      tutorialState: completeTutorialStep(
+        dismissCurrentHint(state.tutorialState),
+        stepId
+      ),
+    };
+  }
+
+  if (action.type === 'TUTORIAL_DISABLE') {
+    if (!state.tutorialState) return null;
+    return {
+      ...state,
+      tutorialState: {
+        ...dismissCurrentHint(state.tutorialState),
+        hintsEnabled: false,
+      },
+    };
   }
 
   return null;

--- a/src/main.js
+++ b/src/main.js
@@ -10,6 +10,7 @@ import { handleUIAction } from './handlers/ui-handler.js';
 import { handleDungeonAction } from './handlers/dungeon-handler.js';
 import { handleStateTransitions } from './state-transitions.js';
 import { initAudio } from './audio-system.js';
+import { createTutorialState } from './tutorial.js';
 
 const IS_BROWSER = typeof window !== 'undefined' && typeof document !== 'undefined';
 
@@ -17,7 +18,7 @@ if (IS_BROWSER) {
   // Initialize theme from settings
   const initialSettings = loadSettings();
   applyTheme(initialSettings.display?.theme || 'midnight');
-  let state = { phase: 'class-select', log: ['Welcome to AI Village RPG! Select your class.'] };
+  let state = { phase: 'class-select', log: ['Welcome to AI Village RPG! Select your class.'], tutorialState: createTutorialState() };
 
   // Initialize audio system on first interaction
   const startAudio = async () => {

--- a/src/render.js
+++ b/src/render.js
@@ -36,6 +36,8 @@ import { triggerFloatingTextFromLog, getFloatingTextStyles } from './floating-te
 import { renderBattleLogPanel, getBattleLogStyles } from './battle-log-ui.js';
 import { getBattleLogEntries } from './combat-battle-log-integration.js';
 import { filterAndSortItems, renderSortFilterControls, SORT_MODES, FILTER_MODES } from './inventory-sort-filter.js';
+import { renderTutorialHint, attachTutorialHandlers, getTutorialStyles } from './tutorial-ui.js';
+import { getTutorialHint } from './tutorial.js';
 import { BACKGROUND_ORDER, BACKGROUNDS } from './data/backgrounds.js';
 
 /** Track previous log for floating text diff */
@@ -286,6 +288,12 @@ export function render(state, dispatch) {
     blStyleEl.textContent = getBattleLogStyles();
     document.head.appendChild(blStyleEl);
   }
+  if (!document.getElementById('tutorial-styles')) {
+    const tutStyleEl = document.createElement('style');
+    tutStyleEl.id = 'tutorial-styles';
+    tutStyleEl.textContent = getTutorialStyles();
+    document.head.appendChild(tutStyleEl);
+  }
 
   const finalizeRender = () => {
     if (state.showHelp) {
@@ -303,6 +311,35 @@ export function render(state, dispatch) {
       triggerFloatingTextFromLog(state.log, _previousLog);
     }
     _previousLog = state.log ? [...state.log] : [];
+
+    // Tutorial hint triggers
+    if (state.tutorialState && state.tutorialState.hintsEnabled) {
+      let triggerEvent = null;
+      if (state.phase === 'class-select' && !state.tutorialState.completedSteps.includes('welcome')) triggerEvent = 'class-select';
+      else if (state.phase === 'exploration' && !state.tutorialState.completedSteps.includes('exploration-basics')) triggerEvent = 'first-exploration';
+      else if ((state.phase === 'player-turn' || state.phase === 'enemy-turn') && !state.tutorialState.completedSteps.includes('combat-intro')) triggerEvent = 'first-combat';
+      else if (state.phase === 'inventory' && !state.tutorialState.completedSteps.includes('inventory-intro')) triggerEvent = 'first-inventory';
+      else if (state.phase === 'shop' && !state.tutorialState.completedSteps.includes('shop-intro')) triggerEvent = 'first-shop';
+      else if (state.phase === 'dungeon' && !state.tutorialState.completedSteps.includes('dungeon-intro')) triggerEvent = 'first-dungeon';
+      else if (state.phase === 'level-up' && !state.tutorialState.completedSteps.includes('level-up-intro')) triggerEvent = 'first-level-up';
+      else if (state.phase === 'quests' && !state.tutorialState.completedSteps.includes('quest-intro')) triggerEvent = 'first-quest';
+      else if (state.phase === 'crafting' && !state.tutorialState.completedSteps.includes('crafting-intro')) triggerEvent = 'first-crafting';
+      else if (state.phase === 'companions' && !state.tutorialState.completedSteps.includes('companion-intro')) triggerEvent = 'first-companion';
+
+      if (triggerEvent) {
+        const hint = getTutorialHint(state.tutorialState, triggerEvent);
+        if (hint && state.tutorialState.currentHint?.id !== hint.id) {
+          dispatch({ type: 'TUTORIAL_SHOW', stepId: hint.id });
+        }
+      }
+    }
+
+    // Render tutorial overlay
+    const tutorialHtml = renderTutorialHint(state.tutorialState);
+    if (tutorialHtml) {
+      hud.innerHTML += tutorialHtml;
+      attachTutorialHandlers(dispatch);
+    }
   };
 
   // --- Class Select Phase ---

--- a/src/tutorial-ui.js
+++ b/src/tutorial-ui.js
@@ -1,0 +1,156 @@
+import { getTutorialProgress } from './tutorial.js';
+
+export function getTutorialStyles() {
+  return `
+.tutorial-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.4);
+  z-index: 10001;
+  display: flex;
+  pointer-events: auto;
+}
+
+.tutorial-tooltip {
+  max-width: 480px;
+  background: #1a1a2e;
+  border: 2px solid #e94560;
+  border-radius: 12px;
+  padding: 20px 24px;
+  color: #eee;
+  font-family: monospace;
+  box-shadow: 0 8px 32px rgba(0,0,0,0.6);
+  animation: tutorialFadeIn 0.3s ease-out;
+}
+
+.tutorial-tooltip.position-top {
+  align-self: flex-start;
+  margin-top: 80px;
+}
+
+.tutorial-tooltip.position-bottom {
+  align-self: flex-end;
+  margin-bottom: 80px;
+}
+
+.tutorial-tooltip.position-center {
+  align-self: center;
+}
+
+.tutorial-title {
+  font-size: 1.2em;
+  font-weight: bold;
+  color: #e94560;
+  margin-bottom: 8px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.tutorial-title::before {
+  content: "💡";
+}
+
+.tutorial-message {
+  line-height: 1.6;
+  color: #ccc;
+  margin-bottom: 16px;
+}
+
+.tutorial-actions {
+  display: flex;
+  gap: 12px;
+  justify-content: flex-end;
+}
+
+.tutorial-btn {
+  padding: 8px 20px;
+  border-radius: 6px;
+  border: none;
+  cursor: pointer;
+  font-family: monospace;
+  font-size: 0.9em;
+  transition: all 0.2s;
+}
+
+.tutorial-btn-dismiss {
+  background: #e94560;
+  color: white;
+}
+
+.tutorial-btn-dismiss:hover {
+  background: #ff6b81;
+}
+
+.tutorial-btn-disable {
+  background: transparent;
+  border: 1px solid #555;
+  color: #888;
+}
+
+.tutorial-btn-disable:hover {
+  border-color: #888;
+  color: #ccc;
+}
+
+.tutorial-progress {
+  font-size: 0.75em;
+  color: #666;
+  margin-top: 12px;
+  text-align: right;
+}
+
+@keyframes tutorialFadeIn {
+  from { opacity: 0; transform: translateY(-10px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+`;
+}
+
+export function renderTutorialHint(tutorialState) {
+  if (!tutorialState || !tutorialState.currentHint) {
+    return '';
+  }
+
+  const { currentHint } = tutorialState;
+  const progress = getTutorialProgress(tutorialState);
+
+  return `
+<div class="tutorial-overlay" id="tutorialOverlay">
+  <div class="tutorial-tooltip position-${currentHint.position}">
+    <div class="tutorial-title">${currentHint.title}</div>
+    <div class="tutorial-message">${currentHint.message}</div>
+    <div class="tutorial-actions">
+      <button class="tutorial-btn tutorial-btn-disable" id="btnTutorialDisable">Disable hints</button>
+      <button class="tutorial-btn tutorial-btn-dismiss" id="btnTutorialDismiss">Got it!</button>
+    </div>
+    <div class="tutorial-progress">${progress.completed}/${progress.total} completed</div>
+  </div>
+</div>
+`;
+}
+
+export function attachTutorialHandlers(dispatch) {
+  const dismissBtn = document.getElementById('btnTutorialDismiss');
+  if (dismissBtn) {
+    dismissBtn.addEventListener('click', () => {
+      dispatch({ type: 'TUTORIAL_DISMISS' });
+    });
+  }
+
+  const disableBtn = document.getElementById('btnTutorialDisable');
+  if (disableBtn) {
+    disableBtn.addEventListener('click', () => {
+      dispatch({ type: 'TUTORIAL_DISABLE' });
+    });
+  }
+
+  const overlay = document.getElementById('tutorialOverlay');
+  if (overlay) {
+    overlay.addEventListener('click', (event) => {
+      if (event.target === overlay) {
+        dispatch({ type: 'TUTORIAL_DISMISS' });
+      }
+    });
+  }
+}

--- a/src/tutorial.js
+++ b/src/tutorial.js
@@ -1,0 +1,160 @@
+export const TUTORIAL_STEPS = [
+  {
+    id: 'welcome',
+    trigger: 'class-select',
+    title: 'Welcome, Adventurer!',
+    message: 'Choose a class to begin your journey. Each class has unique abilities and playstyles.',
+    position: 'center',
+  },
+  {
+    id: 'exploration-basics',
+    trigger: 'first-exploration',
+    title: 'Exploring the World',
+    message: 'Click the directional buttons or use WASD to move between areas and discover new locations.',
+    position: 'top',
+  },
+  {
+    id: 'combat-intro',
+    trigger: 'first-combat',
+    title: 'Combat Basics',
+    message: 'Use Attack for basic damage, Defend to reduce incoming damage, and abilities that cost MP for special effects.',
+    position: 'top',
+  },
+  {
+    id: 'inventory-intro',
+    trigger: 'first-inventory',
+    title: 'Your Inventory',
+    message: 'Equipment improves your stats. Use sort and filter controls to organize items quickly.',
+    position: 'top',
+  },
+  {
+    id: 'shop-intro',
+    trigger: 'first-shop',
+    title: 'The Shop',
+    message: 'Buy and sell items here. Rarer items cost more but offer greater power.',
+    position: 'top',
+  },
+  {
+    id: 'dungeon-intro',
+    trigger: 'first-dungeon',
+    title: 'Dungeon Delving',
+    message: 'Dungeons have multiple floors with increasingly powerful enemies. Bring provisions and be prepared.',
+    position: 'center',
+  },
+  {
+    id: 'level-up-intro',
+    trigger: 'first-level-up',
+    title: 'Level Up!',
+    message: 'Gain stats and skill points when you level up. Spend them in the talent tree.',
+    position: 'center',
+  },
+  {
+    id: 'quest-intro',
+    trigger: 'first-quest',
+    title: 'Quests',
+    message: 'Quests provide objectives and rewards. Check the quest log for details.',
+    position: 'top',
+  },
+  {
+    id: 'crafting-intro',
+    trigger: 'first-crafting',
+    title: 'Crafting',
+    message: 'Combine recipes to create powerful items. Discover new recipes as you explore.',
+    position: 'top',
+  },
+  {
+    id: 'companion-intro',
+    trigger: 'first-companion',
+    title: 'Companions',
+    message: 'Companions can join your party and fight alongside you.',
+    position: 'top',
+  },
+  {
+    id: 'status-effects',
+    trigger: 'first-status-effect',
+    title: 'Status Effects',
+    message: 'Buffs and debuffs affect combat flow. Some wear off over time.',
+    position: 'top',
+  },
+  {
+    id: 'abilities-intro',
+    trigger: 'first-ability-use',
+    title: 'Special Abilities',
+    message: 'Abilities cost MP but can deal elemental damage or apply effects. Watch enemy weaknesses.',
+    position: 'top',
+  },
+];
+
+export function createTutorialState() {
+  return {
+    completedSteps: [],
+    currentHint: null,
+    hintsEnabled: true,
+  };
+}
+
+export function getTutorialHint(tutorialState, triggerEvent) {
+  if (!tutorialState || tutorialState.hintsEnabled === false) {
+    return null;
+  }
+
+  const step = TUTORIAL_STEPS.find((s) => s.trigger === triggerEvent);
+  if (!step) return null;
+  if (tutorialState.completedSteps.includes(step.id)) return null;
+  return step;
+}
+
+export function completeTutorialStep(tutorialState, stepId) {
+  if (!tutorialState || tutorialState.completedSteps.includes(stepId)) {
+    return tutorialState;
+  }
+
+  return {
+    ...tutorialState,
+    completedSteps: [...tutorialState.completedSteps, stepId],
+    currentHint: null,
+  };
+}
+
+export function dismissCurrentHint(tutorialState) {
+  if (!tutorialState) {
+    return tutorialState;
+  }
+
+  return {
+    ...tutorialState,
+    currentHint: null,
+  };
+}
+
+export function showHint(tutorialState, stepId) {
+  if (!tutorialState) {
+    return tutorialState;
+  }
+
+  const step = TUTORIAL_STEPS.find((entry) => entry.id === stepId);
+  if (!step) {
+    return tutorialState;
+  }
+
+  return {
+    ...tutorialState,
+    currentHint: step,
+  };
+}
+
+export function resetTutorial() {
+  return createTutorialState();
+}
+
+export function getTutorialProgress(tutorialState) {
+  const total = TUTORIAL_STEPS.length;
+  const completed = tutorialState ? tutorialState.completedSteps.length : 0;
+  const percentage = total === 0 ? 0 : Math.round((completed / total) * 100);
+
+  return {
+    completed,
+    total,
+    percentage,
+  };
+}

--- a/tests/tutorial-test.mjs
+++ b/tests/tutorial-test.mjs
@@ -1,0 +1,222 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  TUTORIAL_STEPS,
+  createTutorialState,
+  getTutorialHint,
+  completeTutorialStep,
+  dismissCurrentHint,
+  showHint,
+  resetTutorial,
+  getTutorialProgress,
+} from '../src/tutorial.js';
+import { renderTutorialHint, attachTutorialHandlers } from '../src/tutorial-ui.js';
+
+describe('createTutorialState', () => {
+  it('returns object with empty completedSteps array', () => {
+    const state = createTutorialState();
+    assert.ok(Array.isArray(state.completedSteps));
+    assert.equal(state.completedSteps.length, 0);
+  });
+
+  it('returns object with null currentHint', () => {
+    const state = createTutorialState();
+    assert.equal(state.currentHint, null);
+  });
+
+  it('returns object with hintsEnabled true', () => {
+    const state = createTutorialState();
+    assert.equal(state.hintsEnabled, true);
+  });
+});
+
+describe('TUTORIAL_STEPS', () => {
+  it('has at least 12 steps', () => {
+    assert.ok(TUTORIAL_STEPS.length >= 12);
+  });
+
+  it('all steps have required fields', () => {
+    for (const step of TUTORIAL_STEPS) {
+      assert.ok(step.id);
+      assert.ok(step.trigger);
+      assert.ok(step.title);
+      assert.ok(step.message);
+      assert.ok(step.position);
+    }
+  });
+
+  it('all step ids are unique', () => {
+    const ids = new Set(TUTORIAL_STEPS.map((step) => step.id));
+    assert.equal(ids.size, TUTORIAL_STEPS.length);
+  });
+
+  it('all positions are valid', () => {
+    const valid = new Set(['top', 'bottom', 'center']);
+    for (const step of TUTORIAL_STEPS) {
+      assert.ok(valid.has(step.position));
+    }
+  });
+});
+
+describe('getTutorialHint', () => {
+  it('returns matching step for a valid trigger', () => {
+    const state = createTutorialState();
+    const hint = getTutorialHint(state, 'first-combat');
+    assert.equal(hint?.id, 'combat-intro');
+  });
+
+  it('returns null for completed trigger', () => {
+    const state = createTutorialState();
+    state.completedSteps.push('combat-intro');
+    const hint = getTutorialHint(state, 'first-combat');
+    assert.equal(hint, null);
+  });
+
+  it('returns null when hintsEnabled is false', () => {
+    const state = createTutorialState();
+    state.hintsEnabled = false;
+    const hint = getTutorialHint(state, 'first-combat');
+    assert.equal(hint, null);
+  });
+
+  it('returns null for unknown trigger', () => {
+    const state = createTutorialState();
+    const hint = getTutorialHint(state, 'unknown-event');
+    assert.equal(hint, null);
+  });
+});
+
+describe('completeTutorialStep', () => {
+  it('adds stepId to completedSteps', () => {
+    const state = createTutorialState();
+    const next = completeTutorialStep(state, 'combat-intro');
+    assert.ok(next.completedSteps.includes('combat-intro'));
+  });
+
+  it('sets currentHint to null', () => {
+    const state = { ...createTutorialState(), currentHint: TUTORIAL_STEPS[0] };
+    const next = completeTutorialStep(state, 'combat-intro');
+    assert.equal(next.currentHint, null);
+  });
+
+  it('does not duplicate stepId if already completed', () => {
+    const state = { ...createTutorialState(), completedSteps: ['combat-intro'] };
+    const next = completeTutorialStep(state, 'combat-intro');
+    assert.equal(next.completedSteps.length, 1);
+  });
+
+  it('preserves hintsEnabled value', () => {
+    const state = { ...createTutorialState(), hintsEnabled: false };
+    const next = completeTutorialStep(state, 'combat-intro');
+    assert.equal(next.hintsEnabled, false);
+  });
+});
+
+describe('dismissCurrentHint', () => {
+  it('sets currentHint to null', () => {
+    const state = { ...createTutorialState(), currentHint: TUTORIAL_STEPS[0] };
+    const next = dismissCurrentHint(state);
+    assert.equal(next.currentHint, null);
+  });
+
+  it('preserves completedSteps', () => {
+    const state = { ...createTutorialState(), completedSteps: ['combat-intro'] };
+    const next = dismissCurrentHint(state);
+    assert.deepEqual(next.completedSteps, ['combat-intro']);
+  });
+});
+
+describe('showHint', () => {
+  it('sets currentHint to matching step', () => {
+    const state = createTutorialState();
+    const next = showHint(state, 'combat-intro');
+    assert.equal(next.currentHint?.id, 'combat-intro');
+  });
+
+  it('returns unchanged state for unknown stepId', () => {
+    const state = createTutorialState();
+    const next = showHint(state, 'missing-step');
+    assert.equal(next, state);
+  });
+});
+
+describe('resetTutorial', () => {
+  it('returns fresh state with empty completedSteps', () => {
+    const next = resetTutorial();
+    assert.equal(next.completedSteps.length, 0);
+    assert.equal(next.currentHint, null);
+  });
+});
+
+describe('getTutorialProgress', () => {
+  it('returns 0% for fresh state', () => {
+    const progress = getTutorialProgress(createTutorialState());
+    assert.equal(progress.percentage, 0);
+  });
+
+  it('returns correct percentage after completing steps', () => {
+    const state = createTutorialState();
+    state.completedSteps = ['welcome', 'combat-intro', 'quest-intro'];
+    const progress = getTutorialProgress(state);
+    assert.equal(progress.completed, 3);
+    assert.equal(progress.percentage, Math.round((3 / TUTORIAL_STEPS.length) * 100));
+  });
+
+  it('returns 100% when all steps completed', () => {
+    const state = createTutorialState();
+    state.completedSteps = TUTORIAL_STEPS.map((step) => step.id);
+    const progress = getTutorialProgress(state);
+    assert.equal(progress.percentage, 100);
+  });
+});
+
+describe('renderTutorialHint', () => {
+  it('returns empty string when state is null', () => {
+    assert.equal(renderTutorialHint(null), '');
+  });
+
+  it('returns empty string when currentHint is null', () => {
+    const state = createTutorialState();
+    assert.equal(renderTutorialHint(state), '');
+  });
+
+  it('returns HTML with tutorial-overlay class when hint active', () => {
+    const state = { ...createTutorialState(), currentHint: TUTORIAL_STEPS[0] };
+    const html = renderTutorialHint(state);
+    assert.ok(html.includes('tutorial-overlay'));
+  });
+
+  it('includes title and message text in output', () => {
+    const step = TUTORIAL_STEPS[0];
+    const state = { ...createTutorialState(), currentHint: step };
+    const html = renderTutorialHint(state);
+    assert.ok(html.includes(step.title));
+    assert.ok(html.includes(step.message));
+  });
+
+  it('includes position class in tooltip', () => {
+    const step = TUTORIAL_STEPS.find((entry) => entry.position === 'top');
+    const state = { ...createTutorialState(), currentHint: step };
+    const html = renderTutorialHint(state);
+    assert.ok(html.includes(`position-${step.position}`));
+  });
+});
+
+describe('attachTutorialHandlers', () => {
+  let originalDocument;
+
+  beforeEach(() => {
+    originalDocument = global.document;
+    global.document = {
+      getElementById: () => null,
+    };
+  });
+
+  afterEach(() => {
+    global.document = originalDocument;
+  });
+
+  it('does not throw when elements not found', () => {
+    assert.doesNotThrow(() => attachTutorialHandlers(() => {}));
+  });
+});


### PR DESCRIPTION
## Tutorial & Help System

Adds a contextual tutorial system that guides new players through the game's major features.

### Features
- **12 tutorial steps** covering: welcome, exploration, combat, inventory, shop, dungeon, level-up, quests, crafting, companions, status effects, abilities
- **Phase-based triggers**: Hints auto-show on first visit to each game phase
- **Non-intrusive UI**: Fade-in tooltip overlay with position variants (top/center/bottom)
- **Player controls**: 'Got it!' to dismiss + mark completed, 'Disable hints' to turn off all tutorials
- **Persistent state**: Tracks completed steps and hint preference via tutorialState
- Click-outside-overlay to dismiss

### Files Changed
- `src/tutorial.js` - Core tutorial logic (step definitions, state management)
- `src/tutorial-ui.js` - Tooltip rendering, styles, event handlers
- `src/render.js` - Style injection + phase trigger detection in finalizeRender()
- `src/handlers/ui-handler.js` - TUTORIAL_SHOW, TUTORIAL_DISMISS, TUTORIAL_DISABLE actions
- `src/main.js` - Initialize tutorialState in initial game state
- `tests/tutorial-test.mjs` - 29 tests across 10 suites, all passing

### Testing
- 29 dedicated tutorial tests (all passing)
- Full test suite passes (run-tests.mjs + test:shop)
- No regressions