### PR TITLE
feat: Add Oblivion Master achievement for floor 15

### DIFF
--- a/src/achievements.js
+++ b/src/achievements.js
@@ -420,6 +420,14 @@ const ACHIEVEMENTS = [
     getProgress: (data) => Math.min(data.deepestFloor, 10)
   },
   {
+    id: 'oblivion_master',
+    name: 'Oblivion Master',
+    description: 'Reach floor 15 — the Primordial Depths',
+    category: 'dungeon',
+    condition: (data) => data.deepestFloor >= 15,
+    getProgress: (data) => Math.min(data.deepestFloor, 15)
+  },
+  {
     id: 'floor_clearer',
     name: 'Floor Clearer',
     description: 'Clear all enemies on 3 dungeon floors',


### PR DESCRIPTION
## Summary
Adds a new dungeon achievement for reaching floor 15, complementing the existing floor 5, 7, and 10 achievements.

## Changes
- Added 'oblivion_master' achievement in src/achievements.js
- Unlocks when player reaches floor 15 (the Primordial Depths)
- Follows same pattern as abyss_conqueror achievement

## Testing
- Ran tests/achievements-test.mjs: 51 tests passed
- Achievement follows established patterns for dungeon progression

## Motivation
With floors 11-15 now in the game (PR #295), we needed a corresponding achievement for reaching the deepest floor.