### PR TITLE
feat: Integrate equipment sets UI panel into inventory view

### DIFF
--- a/src/render.js
+++ b/src/render.js
@@ -39,6 +39,7 @@ import { getBattleLogEntries } from './combat-battle-log-integration.js';
 import { filterAndSortItems, renderSortFilterControls, SORT_MODES, FILTER_MODES } from './inventory-sort-filter.js';
 import { renderTutorialHint, attachTutorialHandlers, getTutorialStyles } from './tutorial-ui.js';
 import { getTutorialHint } from './tutorial.js';
+import { renderEquipmentSetsPanel, getEquipmentSetsPanelStyles } from './equipment-sets-ui.js';
 import { BACKGROUND_ORDER, BACKGROUNDS } from './data/backgrounds.js';
 
 /** Track previous log for floating text diff */
@@ -1335,6 +1336,15 @@ if (state.phase === 'achievements') {
     const baseDef = player?.def ?? 0;
     const baseSpd = player?.spd ?? 0;
     const effectiveStats = getEffectiveCombatStats(player || {});
+    const equipSetsHtml = renderEquipmentSetsPanel(equipment, { showInactive: true });
+
+    // Equipment sets panel styles
+    if (!document.getElementById('equipment-sets-panel-styles')) {
+      const setsStyle = document.createElement('style');
+      setsStyle.id = 'equipment-sets-panel-styles';
+      setsStyle.textContent = getEquipmentSetsPanelStyles();
+      document.head.appendChild(setsStyle);
+    }
 
     hud.innerHTML = `
       <div class="row">
@@ -1342,6 +1352,10 @@ if (state.phase === 'achievements') {
           <h2>Equipment</h2>
           <div class="kv">${eqRows}</div>
           ${hasBonuses ? `<h3 style="margin-top:8px;color:#aaa;">Total Bonuses</h3><div class="kv">${bonusSummaryRows}</div>` : ''}
+        </div>
+        <div class="card">
+          <h2>Equipment Sets <button id="toggleSetsBtn" style="float:right;font-size:0.8em;">Show/Hide</button></h2>
+          <div id="equipSetsContainer">${equipSetsHtml}</div>
         </div>
         <div class="card">
           <h2>${esc(player?.name || 'Player')} — Lv ${player?.level || 1}</h2>
@@ -1399,6 +1413,16 @@ if (state.phase === 'achievements') {
         else if (action2 === 'details') dispatch({ type: 'INVENTORY_VIEW_DETAILS', itemId });
       };
     });
+
+    const toggleSetsBtn = document.getElementById('toggleSetsBtn');
+    if (toggleSetsBtn) {
+      const setsContainer = document.getElementById('equipSetsContainer');
+      toggleSetsBtn.onclick = () => {
+        if (!setsContainer) return;
+        const isHidden = setsContainer.style.display === 'none';
+        setsContainer.style.display = isHidden ? '' : 'none';
+      };
+    }
 
     log.innerHTML = state.log.slice().reverse().map(line => formatLogEntryHtml(line)).join('');
     finalizeRender();

--- a/tests/equipment-sets-integration-test.mjs
+++ b/tests/equipment-sets-integration-test.mjs
@@ -1,0 +1,71 @@
+/**
+ * Equipment Sets Integration Test — AI Village RPG
+ * Tests that equipment sets UI is properly integrated into render.js
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'fs';
+import path from 'path';
+
+test('Equipment Sets Integration', async (t) => {
+  const renderPath = path.join(process.cwd(), 'src', 'render.js');
+  const renderContent = fs.readFileSync(renderPath, 'utf8');
+
+  await t.test('render.js imports equipment-sets-ui functions', () => {
+    assert.ok(
+      renderContent.includes("import { renderEquipmentSetsPanel, getEquipmentSetsPanelStyles } from './equipment-sets-ui.js'"),
+      'Should import renderEquipmentSetsPanel and getEquipmentSetsPanelStyles'
+    );
+  });
+
+  await t.test('render.js calls renderEquipmentSetsPanel in inventory phase', () => {
+    assert.ok(
+      renderContent.includes('renderEquipmentSetsPanel(equipment'),
+      'Should call renderEquipmentSetsPanel with equipment'
+    );
+  });
+
+  await t.test('render.js injects equipment sets panel styles', () => {
+    assert.ok(
+      renderContent.includes("equipment-sets-panel-styles"),
+      'Should have style element ID for equipment sets panel'
+    );
+    assert.ok(
+      renderContent.includes('getEquipmentSetsPanelStyles()'),
+      'Should call getEquipmentSetsPanelStyles'
+    );
+  });
+
+  await t.test('render.js includes Equipment Sets card in inventory HUD', () => {
+    assert.ok(
+      renderContent.includes('Equipment Sets'),
+      'Should have Equipment Sets heading'
+    );
+    assert.ok(
+      renderContent.includes('toggleSetsBtn'),
+      'Should have toggle button for equipment sets'
+    );
+    assert.ok(
+      renderContent.includes('equipSetsContainer'),
+      'Should have container for equipment sets panel'
+    );
+  });
+
+  await t.test('render.js has toggle handler for equipment sets visibility', () => {
+    assert.ok(
+      renderContent.includes("getElementById('toggleSetsBtn')"),
+      'Should get toggle button element'
+    );
+    assert.ok(
+      renderContent.includes("getElementById('equipSetsContainer')"),
+      'Should get sets container element'
+    );
+    assert.ok(
+      renderContent.includes("style.display === 'none'") || renderContent.includes("display === 'none'"),
+      'Should check display state for toggle'
+    );
+  });
+});
+
+console.log('Equipment Sets Integration Tests: Starting...');


### PR DESCRIPTION
## Summary
This PR wires the equipment sets UI (from PR #310) into the main game UI, allowing players to see their active equipment sets and bonuses in the inventory screen.

## Changes
- Import `renderEquipmentSetsPanel` and `getEquipmentSetsPanelStyles` from equipment-sets-ui.js
- Add Equipment Sets card to inventory HUD between Equipment and Player stats cards
- Inject equipment sets panel styles dynamically with deduplication check
- Add Show/Hide toggle button for collapsible equipment sets display
- Add 6 integration tests verifying the wiring is correct

## Features
- Shows active equipment sets with their stat bonuses
- Displays progress bars for incomplete sets
- Lists missing items needed to complete each set
- Collapsible panel to save screen space

## Testing
- 6 new integration tests pass
- All existing tests pass
- Manual: Open inventory to see Equipment Sets panel

## Author
Claude Opus 4.5