### PR TITLE
feat: Wire displayName field into combat UI and player-facing logs

### DIFF
--- a/src/combat.js
+++ b/src/combat.js
@@ -112,8 +112,8 @@ function processTurnStart(state, actorKey) {
   if (!actor) return state;
 
   let nextState = state;
-  const actorName = actorKey === 'player' ? 'You' : state.enemy.name;
-  const actorPossessive = actorKey === 'player' ? 'Your' : `${state.enemy.name}'s`;
+  const actorName = actorKey === 'player' ? 'You' : (state.enemy.displayName ?? state.enemy.name);
+  const actorPossessive = actorKey === 'player' ? 'Your' : `${(state.enemy.displayName ?? state.enemy.name)}'s`;
   let hp = actor.hp;
   const remainingEffects = [];
 
@@ -121,7 +121,7 @@ function processTurnStart(state, actorKey) {
     const duration = effect.duration ?? 0;
     if (duration <= 0) {
       nextState = pushLog(nextState, `${actorPossessive} ${effect.type} wears off.`);
-      logStatusExpired(effect.type, actorKey === 'player' ? 'Player' : state.enemy.name);
+      logStatusExpired(effect.type, actorKey === 'player' ? 'Player' : (state.enemy.displayName ?? state.enemy.name));
       continue;
     }
 
@@ -194,12 +194,12 @@ function applyVictoryDefeat(state) {
         state = pushLog(state, `Loot: ${loot.name} (${loot.rarity})`);
       }
     }
-    logVictory(state.enemy.name, xpGained, goldGained);
-    state = pushLog(state, `Victory! The ${state.enemy.name} dissolves.`);
+    logVictory((state.enemy.displayName ?? state.enemy.name), xpGained, goldGained);
+    state = pushLog(state, `Victory! The ${(state.enemy.displayName ?? state.enemy.name)} dissolves.`);
     // Log to journal
-    state = logCombatVictory(state, state.enemy.name, goldGained, xpGained);
+    state = logCombatVictory(state, (state.enemy.displayName ?? state.enemy.name), goldGained, xpGained);
     if (state.enemy.isBoss) {
-      state = logBossDefeat(state, state.enemy.name);
+      state = logBossDefeat(state, (state.enemy.displayName ?? state.enemy.name));
     }
     // Companion combat rewards: loyalty adjustments + auto-revive
     state = processCompanionCombatRewards(state);
@@ -243,7 +243,7 @@ export function startNewEncounter(state, zoneLevel = 1) {
   }
   next = { ...next, currentEnemyId: enemyId, bestiary: recordEncounter(next.bestiary || { encountered: [], defeatedCounts: {} }, enemyId) };
 
-  next = pushLog(next, `A wild ${enemy.name} appears.`);
+  next = pushLog(next, `A wild ${enemy.displayName ?? enemy.name} appears.`);
   initCombatBattleLog();
   next = pushLog(next, `Your turn.`);
   return next;
@@ -303,7 +303,7 @@ export function playerAttack(state) {
   };
 
   state = pushLog(state, `You strike for ${damage} damage.`);
-  logPlayerAttack(damage, state.enemy.name);
+  logPlayerAttack(damage, (state.enemy.displayName ?? state.enemy.name));
 
   // Apply weapon on-hit status effect (e.g., freeze, bleed, blind)
   if (state.enemy.hp > 0) {
@@ -474,17 +474,17 @@ export function playerUseAbility(state, abilityId) {
         ...state,
         enemy: { ...state.enemy, hp: enemyHp },
       };
-      let msg = `${state.enemy.name} takes ${damage} ${abilityElement} damage!`;
+      let msg = `${(state.enemy.displayName ?? state.enemy.name)} takes ${damage} ${abilityElement} damage!`;
       if (critical) msg += ' Critical hit!';
       state = pushLog(state, msg);
-      logPlayerAbility(ability.name, damage, abilityElement, state.enemy.name);
+      logPlayerAbility(ability.name, damage, abilityElement, (state.enemy.displayName ?? state.enemy.name));
     }
 
     // Apply status effect to enemy
     if (ability.statusEffect) {
       state = addStatusEffect(state, 'enemy', ability.statusEffect);
-      state = pushLog(state, `${state.enemy.name} is afflicted with ${ability.statusEffect.name}!`);
-      logStatusApplied(ability.statusEffect.name, state.enemy.name, ability.statusEffect.duration ?? 3);
+      state = pushLog(state, `${(state.enemy.displayName ?? state.enemy.name)} is afflicted with ${ability.statusEffect.name}!`);
+      logStatusApplied(ability.statusEffect.name, (state.enemy.displayName ?? state.enemy.name), ability.statusEffect.duration ?? 3);
     }
   } else if (ability.targetType === 'single-ally' || ability.targetType === 'all-allies' || ability.targetType === 'self') {
     // Healing ability targeting player
@@ -601,7 +601,7 @@ export function playerUseItem(state, itemId) {
       enemy: { ...state.enemy, hp: enemyHp },
     };
     state = pushLog(state, `You throw ${item.name} for ${damage} ${element} damage!`);
-    logItemUsed(item.name, `Dealt ${damage} ${element} damage to ${state.enemy.name}`);
+    logItemUsed(item.name, `Dealt ${damage} ${element} damage to ${(state.enemy.displayName ?? state.enemy.name)}`);
     state = applyVictoryDefeat(state);
     if (state.phase === 'victory' || state.phase === 'defeat') return state;
   }
@@ -643,7 +643,7 @@ export function enemyAct(state) {
 
   if (wasEnemyStunned || wasEnemyFrozen) {
     const reason = wasEnemyFrozen ? 'frozen' : 'stunned';
-    state = pushLog(state, `${state.enemy.name} is ${reason} and cannot act!`);
+    state = pushLog(state, `${(state.enemy.displayName ?? state.enemy.name)} is ${reason} and cannot act!`);
     state = processTurnStart(state, 'player');
     if (state.phase === 'victory' || state.phase === 'defeat') return state;
     state = pushLog(state, `Your turn.`);
@@ -653,7 +653,7 @@ export function enemyAct(state) {
   if (state.enemy.isBroken && state.enemy.breakTurnsRemaining > 0) {
     const breakResult = processBreakState(state.enemy);
     state = { ...state, enemy: { ...state.enemy, ...breakResult } };
-    state = pushLog(state, `${state.enemy.name} is recovering from the break and cannot act!`);
+    state = pushLog(state, `${(state.enemy.displayName ?? state.enemy.name)} is recovering from the break and cannot act!`);
     state = processTurnStart(state, 'player');
     if (state.phase === 'victory' || state.phase === 'defeat') return state;
     state = pushLog(state, 'Your turn.');
@@ -666,7 +666,7 @@ export function enemyAct(state) {
   // Silenced enemies cannot use abilities — forced to basic attack
   if (result.action === 'ability' && isSilenced(state.enemy)) {
     result = { ...result, action: 'attack' };
-    state = pushLog(state, `${state.enemy.name} is silenced and cannot use abilities!`);
+    state = pushLog(state, `${(state.enemy.displayName ?? state.enemy.name)} is silenced and cannot use abilities!`);
   }
 
   if (result.action === 'defend') {
@@ -676,7 +676,7 @@ export function enemyAct(state) {
       player: { ...state.player, defending: false },
       turn: state.turn + 1,
     };
-    state = pushLog(state, `${state.enemy.name} takes a defensive stance.`);
+    state = pushLog(state, `${(state.enemy.displayName ?? state.enemy.name)} takes a defensive stance.`);
   } else if (result.action === 'ability') {
     state = executeEnemyAbility(state, result.abilityId);
     state = { ...state, turn: state.turn + 1 };
@@ -700,7 +700,7 @@ export function enemyAct(state) {
         const { seed: blindSeed, value: blindRoll } = nextRng(state.rngSeed ?? 1);
         state = { ...state, rngSeed: blindSeed };
         if (blindRoll < 0.5) {
-          state = pushLog(state, `${state.enemy.name}'s attack misses! (Blinded)`);
+          state = pushLog(state, `${(state.enemy.displayName ?? state.enemy.name)}'s attack misses! (Blinded)`);
           state = {
             ...state,
             enemy: { ...state.enemy, defending: false },
@@ -731,8 +731,8 @@ export function enemyAct(state) {
         turn: state.turn + 1,
       };
 
-      state = pushLog(state, `${state.enemy.name} slams you for ${damage} damage.`);
-      logDamageReceived(damage, state.enemy.name);
+      state = pushLog(state, `${(state.enemy.displayName ?? state.enemy.name)} slams you for ${damage} damage.`);
+      logDamageReceived(damage, (state.enemy.displayName ?? state.enemy.name));
     }
     state = applyVictoryDefeat(state);
   }

--- a/src/enemy-abilities.js
+++ b/src/enemy-abilities.js
@@ -158,7 +158,7 @@ export function executeEnemyAbility(state, abilityId) {
     const suffix = extras.length > 0 ? ` (${extras.join(') (')})` : '';
     nextState = pushLog(
       nextState,
-      `${nextState.enemy.name} uses ${ability.name} for ${damage} damage!${suffix}`
+      `${(nextState.enemy.displayName ?? nextState.enemy.name)} uses ${ability.name} for ${damage} damage!${suffix}`
     );
   } else if (ability.targetType === 'self') {
     if (effect) {
@@ -176,7 +176,7 @@ export function executeEnemyAbility(state, abilityId) {
     const suffix = extras.length > 0 ? ` (${extras.join(') (')})` : '';
     nextState = pushLog(
       nextState,
-      `${nextState.enemy.name} uses ${ability.name}!${suffix}`
+      `${(nextState.enemy.displayName ?? nextState.enemy.name)} uses ${ability.name}!${suffix}`
     );
   }
 

--- a/src/game-integration.js
+++ b/src/game-integration.js
@@ -191,7 +191,7 @@ export function handleExplore(gameState, direction) {
     let combatState = createCombatState(partyCombatants, enemies, updated.rngSeed);
     combatState = calculateTurnOrder(combatState);
     const gamePhase = setGameState(GameState.COMBAT);
-    messages.push(`Encountered ${enemies.map((enemy) => enemy.name).join(', ')}.`);
+    messages.push(`Encountered ${enemies.map((enemy) => (enemy.displayName ?? enemy.name)).join(', ')}.`);
     emit('combat:start', { combatState });
     return { ...updated, gamePhase, combatState, messages };
   }

--- a/src/handlers/dungeon-handler.js
+++ b/src/handlers/dungeon-handler.js
@@ -89,7 +89,7 @@ export function handleDungeonAction(state, action) {
           },
           'You search the floor...'
         ),
-        `A ${enemy.name} attacks! (Floor ${state.dungeonState.currentFloor})`
+        `A ${(enemy.displayName ?? enemy.name)} attacks! (Floor ${state.dungeonState.currentFloor})`
       );
     }
 
@@ -188,7 +188,7 @@ export function handleDungeonAction(state, action) {
         },
         'You challenge the floor boss!'
       ),
-      `A mighty ${enemy.name} appears!`
+      `A mighty ${(enemy.displayName ?? enemy.name)} appears!`
     );
   }
 

--- a/src/render.js
+++ b/src/render.js
@@ -569,7 +569,7 @@ export function render(state, dispatch) {
         <div class="card">
           <h2>Enemy</h2>
           <div class="kv">
-            <div>Name</div><div><b>${esc(state.enemy.name)}</b></div>
+            <div>Name</div><div><b>${esc((state.enemy.displayName ?? state.enemy.name))}</b></div>
             <div>HP</div><div><b>${hpLine(state.enemy)}</b></div>
             <div>ATK / DEF</div><div><b>${state.enemy.atk}</b> / <b>${state.enemy.def}</b></div>
             <div>Defending</div><div><b>${state.enemy.defending ? 'Yes' : 'No'}</b></div>


### PR DESCRIPTION
## Summary
This PR wires the `displayName` field from PR #287 into all combat UI displays and player-facing log messages.

## Problem
PR #287 added procedural enemy name generation via `displayName` field in `getEnemy()`, but the UI never actually used it. All combat logs, enemy panels, and encounter messages still referenced `enemy.name` (the canonical name like "goblin"), so players never saw the procedural names like "Vicious Goblin of Doom".

## Solution
Updated all enemy name references to use the pattern `(enemy.displayName ?? enemy.name)` across:
- **src/combat.js** (21 references) - All combat log messages
- **src/render.js** (1 reference) - Enemy panel name display  
- **src/enemy-abilities.js** (2 references) - Enemy ability announcements
- **src/game-integration.js** (1 reference) - Encounter summary messages
- **src/handlers/dungeon-handler.js** (2 references) - Dungeon encounter and boss messages

## Testing
- Verified all changes preserve fallback behavior (uses `name` if `displayName` is undefined)
- All existing tests should pass since this is a display-only change
- Ready for browser testing to verify procedural names appear correctly

## Related
- Follows up on PR #287 (procedural enemy name generation)
- Completes the displayName feature by making it visible to players