### PR TITLE
feat: Integrate Talent Tree Sort and Filter

### DIFF
--- a/src/handlers/ui-handler.js
+++ b/src/handlers/ui-handler.js
@@ -400,7 +400,34 @@ export function handleUIAction(state, action) {
     if (!state.talentState) {
       state = { ...state, talentState: createTalentState() };
     }
-    return { ...state, phase: 'talents', previousPhase: state.phase };
+    return {
+      ...state,
+      phase: 'talents',
+      previousPhase: state.phase,
+      talentUiState: state.talentUiState || { sortMethod: 'tier', filterText: '' },
+    };
+  }
+
+  if (type === 'SET_TALENT_SORT_METHOD') {
+    if (state.phase !== 'talents') return null;
+    return {
+      ...state,
+      talentUiState: {
+        ...(state.talentUiState || {}),
+        sortMethod: action.sortMethod || 'tier',
+      },
+    };
+  }
+
+  if (type === 'SET_TALENT_FILTER_TEXT') {
+    if (state.phase !== 'talents') return null;
+    return {
+      ...state,
+      talentUiState: {
+        ...(state.talentUiState || {}),
+        filterText: action.filterText || '',
+      },
+    };
   }
 
   if (type === 'ALLOCATE_TALENT') {

--- a/src/talents-sort-filter.js
+++ b/src/talents-sort-filter.js
@@ -228,6 +228,37 @@ export function sortTalents(talents, sort, talentState) {
 // ============ COMBINED SORT & FILTER ============
 
 /**
+ * Apply text filtering and sorting to a provided talent list.
+ * @param {Array} talents - Talent subset to process (for example, one category)
+ * @param {Object} options - Sort/filter options
+ * @param {string} options.sortMethod - UI sort method
+ * @param {string} options.filterText - Free-text filter
+ * @param {Object} options.talentState - Player's talent state
+ * @returns {Array} Filtered/sorted talents
+ */
+export function applyTalentSortFilter(talents, { sortMethod = 'tier', filterText = '', talentState } = {}) {
+  if (!Array.isArray(talents)) return [];
+
+  const normalizedFilter = String(filterText || '').trim().toLowerCase();
+  const normalizedSort = sortMethod === 'points' ? 'allocated' : sortMethod;
+
+  let result = [...talents];
+
+  if (normalizedFilter) {
+    result = result.filter((talent) => {
+      const name = String(talent?.name || '').toLowerCase();
+      const id = String(talent?.id || '').toLowerCase();
+      const description = String(talent?.description || '').toLowerCase();
+      return name.includes(normalizedFilter)
+        || id.includes(normalizedFilter)
+        || description.includes(normalizedFilter);
+    });
+  }
+
+  return sortTalents(result, normalizedSort, talentState);
+}
+
+/**
  * Apply both filter and sort to get final talent list
  * @param {Object} options - Configuration object
  * @param {string} options.filter - Filter value

--- a/src/talents-ui.js
+++ b/src/talents-ui.js
@@ -4,11 +4,12 @@
 
 import { TALENTS, TALENT_CATEGORIES, TIER_REQUIREMENTS, getTalentValue, getTalentDescription, getTalentsByCategory } from './data/talents.js';
 import { getTalentRank, canAllocateTalent, canDeallocateTalent, isTierUnlocked, arePrerequisitesMet } from './talents.js';
+import { applyTalentSortFilter } from './talents-sort-filter.js';
 
 /**
  * Render the talent tree screen
  */
-export function renderTalentTree(state) {
+export function renderTalentTree(state, sortMethod = 'tier', filterText = '') {
   const talentState = state.player?.talents;
   if (!talentState) {
     return `<div class="talent-tree-container">
@@ -20,6 +21,8 @@ export function renderTalentTree(state) {
     </div>`;
   }
 
+  const activeSortMethod = state.talentUiState?.sortMethod ?? sortMethod ?? 'tier';
+  const activeFilterText = state.talentUiState?.filterText ?? filterText ?? '';
   const categories = Object.values(TALENT_CATEGORIES);
   
   let html = `<div class="talent-tree-container">
@@ -32,11 +35,11 @@ export function renderTalentTree(state) {
     </div>
     <div class="talent-controls">
       <select class="talent-sort">
-        <option value="name">Name</option>
-        <option value="tier">Tier</option>
-        <option value="points">Points Invested</option>
+        <option value="name"${activeSortMethod === 'name' ? ' selected' : ''}>Name</option>
+        <option value="tier"${activeSortMethod === 'tier' ? ' selected' : ''}>Tier</option>
+        <option value="points"${activeSortMethod === 'points' ? ' selected' : ''}>Points Invested</option>
       </select>
-      <input type="text" class="talent-filter" placeholder="Filter by name..." />
+      <input type="text" class="talent-filter" placeholder="Filter by name..." value="${escapeAttribute(activeFilterText)}" />
       <button class="talent-filter-apply">Apply Filter</button>
       <button class="talent-filter-clear">Clear Filter</button>
     </div>
@@ -44,7 +47,7 @@ export function renderTalentTree(state) {
     <div class="talent-categories">`;
 
   for (const category of categories) {
-    html += renderCategory(category, talentState);
+    html += renderCategory(category, talentState, activeSortMethod, activeFilterText);
   }
 
   html += `</div>
@@ -61,15 +64,20 @@ export function renderTalentTree(state) {
 /**
  * Render a single talent category
  */
-function renderCategory(category, talentState) {
+function renderCategory(category, talentState, sortMethod, filterText) {
   const talents = getTalentsByCategory(category.id);
+  const sortedFilteredTalents = applyTalentSortFilter(talents, {
+    sortMethod,
+    filterText,
+    talentState
+  });
   const pointsInCategory = talentState.categoryPoints[category.id] || 0;
   
   // Group talents by tier
   const tiers = {
-    1: talents.filter(t => t.tier === 1),
-    2: talents.filter(t => t.tier === 2),
-    3: talents.filter(t => t.tier === 3)
+    1: sortedFilteredTalents.filter(t => t.tier === 1),
+    2: sortedFilteredTalents.filter(t => t.tier === 2),
+    3: sortedFilteredTalents.filter(t => t.tier === 3)
   };
 
   let html = `<div class="talent-category" style="border-color: ${category.color}">
@@ -100,6 +108,14 @@ function renderCategory(category, talentState) {
 
   html += `</div>`;
   return html;
+}
+
+function escapeAttribute(value) {
+  return String(value)
+    .replaceAll('&', '&amp;')
+    .replaceAll('"', '&quot;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;');
 }
 
 /**
@@ -527,6 +543,20 @@ export function getTalentTreeStyles() {
 }
 
 export function attachTalentHandlers(container, dispatch) {
+  const sortSelect = container.querySelector('.talent-sort');
+  if (sortSelect) {
+    sortSelect.addEventListener('change', () => {
+      dispatch({ type: 'SET_TALENT_SORT_METHOD', sortMethod: sortSelect.value });
+    });
+  }
+
+  const filterInput = container.querySelector('.talent-filter');
+  if (filterInput) {
+    filterInput.addEventListener('input', () => {
+      dispatch({ type: 'SET_TALENT_FILTER_TEXT', filterText: filterInput.value });
+    });
+  }
+
   container.addEventListener('click', (e) => {
     const btn = e.target.closest('[data-action]');
     if (!btn) return;
@@ -543,4 +573,19 @@ export function attachTalentHandlers(container, dispatch) {
       dispatch({ type: 'CLOSE_TALENTS' });
     }
   });
+
+  const applyFilterButton = container.querySelector('.talent-filter-apply');
+  if (applyFilterButton && filterInput) {
+    applyFilterButton.addEventListener('click', () => {
+      dispatch({ type: 'SET_TALENT_FILTER_TEXT', filterText: filterInput.value });
+    });
+  }
+
+  const clearFilterButton = container.querySelector('.talent-filter-clear');
+  if (clearFilterButton && filterInput) {
+    clearFilterButton.addEventListener('click', () => {
+      filterInput.value = '';
+      dispatch({ type: 'SET_TALENT_FILTER_TEXT', filterText: '' });
+    });
+  }
 }


### PR DESCRIPTION
Wires up the talent tree sorting and filtering UI controls from PR #314 to the logic module from PR #315. Allows players to sort talents by name, tier, or points invested, and filter by text search.