### PR TITLE
fix: reset inventory to potion in NG+

### DIFF
--- a/src/handlers/system-handler.js
+++ b/src/handlers/system-handler.js
@@ -146,7 +146,7 @@ export function handleSystemAction(state, action) {
         defending: false,
       },
       gold: Math.floor((state.gold || 0) * 0.5),
-      inventory: (state.inventory || []).filter(i => i.equipped),
+      inventory: { potion: 2 },
       log: [
         `New Game+ ${ngPlusCount} begins! Your power carries forward, but the dungeon grows stronger...`,
         'The Oblivion Lord has reformed. The cycle continues.',


### PR DESCRIPTION
Fixes a bug where .filter was called on the inventory object in the New Game+ handler. Inventory is now properly reset.