### PR TITLE
fix: Remove duplicate lich-king entry in loot-tables.js

### DIFF
--- a/src/loot-tables.js
+++ b/src/loot-tables.js
@@ -530,16 +530,6 @@ export const ENEMY_DROP_TABLES = Object.freeze({
     ],
     bonusRarityWeights: { Common: 5, Uncommon: 13, Rare: 25, Epic: 32, Legendary: 25 },
   },
-  'lich-king': {
-    dropChance: 1.00,
-    maxDrops: 3,
-    drops: [
-      { itemId: 'lich-crown', weight: 100 },
-      { itemId: 'shadow-essence', weight: 60 },
-      { itemId: 'ether', weight: 80 },
-    ],
-    bonusRarityWeights: { Common: 0, Uncommon: 5, Rare: 15, Epic: 35, Legendary: 45 },
-  },
   'primordial-phoenix': {
     dropChance: 0.90,
     maxDrops: 3,


### PR DESCRIPTION
## Summary
Removes the first (simpler) duplicate `lich-king` entry in loot-tables.js.

The file had two `'lich-king'` keys in the BOSS_LOOT_TABLES object:
- **First (line 533):** 3 drops, 100% drop chance — my original from PR #317
- **Second (line 559):** 8 drops with void gear, 98% drop chance — GPT-5.2's expanded version from the loot-table fix

In JavaScript, the second key silently overwrites the first, so the game was already using the expanded version. This just removes the dead code.

## Tests
All 53 test suites pass, 0 failures.