### PR TITLE
tests: add New Game+ semantics regression guard (Node-only)

### DIFF
--- a/tests/new-game-plus-test.mjs
+++ b/tests/new-game-plus-test.mjs
@@ -1,0 +1,114 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { handleSystemAction } from '../src/handlers/system-handler.js';
+
+function makeEndgameState(overrides = {}) {
+  const bestiary = { goblin: { seen: true } };
+  const tutorialState = { seenIntro: true };
+  const gameStats = { enemiesDefeated: 99, battlesWon: 50, battlesFled: 3 };
+  const state = {
+    phase: 'victory',
+    gold: 1234,
+    log: ['GAME COMPLETE'],
+    player: {
+      name: 'Hero',
+      classId: 'warrior',
+      level: 15,
+      hp: 1,
+      mp: 0,
+      maxHp: 120,
+      maxMp: 40,
+      defending: true,
+      equipment: {
+        weapon: { id: 'greatsword', atk: 12 },
+        armor: { id: 'steel-mail', def: 8 },
+      },
+      // Intentionally as an object map to assert reset semantics
+      inventory: { potion: 5, ether: 1 },
+    },
+    bestiary,
+    tutorialState,
+    gameStats,
+    newGamePlusCount: overrides.newGamePlusCount ?? 0,
+    ...overrides,
+  };
+  return state;
+}
+
+describe('NEW_GAME_PLUS semantics (regression guard for PR #326)', () => {
+  it('transitions without throwing and sets expected baseline fields', () => {
+    const pre = makeEndgameState();
+    const next = handleSystemAction(pre, { type: 'NEW_GAME_PLUS' });
+
+    // No throw and returns an object
+    assert.ok(next && typeof next === 'object');
+
+    // Phase set to exploration
+    assert.equal(next.phase, 'exploration');
+
+    // Inventory is reset to an object map with exactly { potion: 2 }
+    assert.ok(next.inventory && typeof next.inventory === 'object' && !Array.isArray(next.inventory));
+    assert.deepEqual(next.inventory, { potion: 2 });
+
+    // Equipment persists under player and is not duplicated into inventory
+    assert.ok(next.player && next.player.equipment && typeof next.player.equipment === 'object');
+    assert.deepEqual(Object.keys(next.player.equipment).sort(), ['armor', 'weapon']);
+    assert.equal(next.inventory.weapon, undefined);
+    assert.equal(next.inventory.armor, undefined);
+
+    // HP/MP reset to max values; defending cleared
+    assert.equal(next.player.hp, pre.player.maxHp || 50);
+    assert.equal(next.player.mp, pre.player.maxMp || 15);
+    assert.equal(next.player.defending, false);
+
+    // Gold carryover is halved and floored
+    assert.equal(next.gold, Math.floor((pre.gold || 0) * 0.5));
+
+    // Flags and counters
+    assert.equal(next.newGamePlus, true);
+    assert.equal(next.newGamePlusCount, (pre.newGamePlusCount || 0) + 1);
+    assert.equal(next.newGamePlusBonus, next.newGamePlusCount);
+
+    // Log includes NG+ banner and Oblivion Lord message
+    const log = next.log || [];
+    assert.ok(Array.isArray(log) && log.length >= 2);
+    assert.ok(log.some(l => typeof l === 'string' && l.includes('New Game+')));
+    assert.ok(log.some(l => typeof l === 'string' && l.includes('Oblivion Lord')));
+
+    // Reference preservation: these should be the exact same object references
+    assert.strictEqual(next.bestiary, pre.bestiary);
+    assert.strictEqual(next.tutorialState, pre.tutorialState);
+    assert.strictEqual(next.gameStats, pre.gameStats);
+  });
+
+  it('uses safe fallbacks for missing maxHp/maxMp and gold', () => {
+    const pre = makeEndgameState({
+      gold: undefined,
+      player: {
+        name: 'Rogue', classId: 'rogue', level: 10,
+        hp: 0, mp: 0, maxHp: undefined, maxMp: undefined,
+        defending: true,
+        equipment: {},
+        inventory: {},
+      },
+    });
+
+    const next = handleSystemAction(pre, { type: 'NEW_GAME_PLUS' });
+
+    // Fallbacks 50/15 are applied when max values are missing
+    assert.equal(next.player.hp, 50);
+    assert.equal(next.player.mp, 15);
+
+    // Gold fallback halving: undefined treated as 0
+    assert.equal(next.gold, 0);
+  });
+
+  it('increments newGamePlusCount across successive NG+ transitions', () => {
+    const first = handleSystemAction(makeEndgameState({ newGamePlusCount: 0 }), { type: 'NEW_GAME_PLUS' });
+    assert.equal(first.newGamePlusCount, 1);
+
+    const second = handleSystemAction(first, { type: 'NEW_GAME_PLUS' });
+    assert.equal(second.newGamePlusCount, 2);
+    assert.equal(second.newGamePlusBonus, 2);
+  });
+});


### PR DESCRIPTION
This PR adds a deterministic Node-only regression test suite for New Game+ semantics, locking in the behavior established by PR #326 and tracked in Issue #328.

What’s included
- New test file: tests/new-game-plus-test.mjs
  - No DOM usage; imports handleSystemAction directly from src/handlers/system-handler.js and runs under Node with existing harness.
  - Asserts the following invariants:
    1) No-throw NG+ transition via handleSystemAction(pre, { type: 'NEW_GAME_PLUS' }), returning an object.
    2) Phase → 'exploration'.
    3) Inventory semantics: reset to an object map with exactly { potion: 2 } (not an array; no old contents).
    4) Equipment persistence: remains under player.equipment and is NOT duplicated into inventory.
    5) HP/MP reset: to max values when present; safe fallbacks hp=50/mp=15 when maxHp/maxMp are missing.
    6) Gold carryover: Math.floor((state.gold || 0) * 0.5).
    7) Flags/counters: newGamePlus=true; newGamePlusCount increments; newGamePlusBonus === newGamePlusCount; successive NG+ calls increment as expected.
    8) Log content: includes “New Game+ ${count} begins!” and “The Oblivion Lord has reformed...” strings.
    9) Reference preservation: next.bestiary, next.tutorialState, and next.gameStats are strict-equal to pre versions.

Security & test posture
- Deterministic, Node-only tests; no top-level DOM or side effects.
- No changes to runtime code; only adds tests.
- Verified locally:
  - scripts/run-tests.mjs (full) — green.
  - npm run test:shop — green.
  - npm run security-scan (enhanced scanner v3) — 0 issues across 326 files.
  - Forbidden motifs, zero-width, audio-whitespace, and docs baseline guards remain intact (no modifications to guard suites).

Why this matters
- PR #326 fixed a crash from treating inventory as an array. This PR prevents regressions by explicitly pinning inventory to a plain object map and validating the broader NG+ contract, including logs and carryover rules.

Notes
- CI for PR check-runs has been intermittently blocked for agent accounts. Even if PR checks don’t attach, main-branch CI continues to run on merge pushes. Human maintainer assistance may be needed to restore PR automation.

Refs: #328, #326
