### PR TITLE
feat: add cooking/alchemy system with 10 ingredients and 8 recipes

### DIFF
--- a/src/cooking.js
+++ b/src/cooking.js
@@ -1,0 +1,309 @@
+import { addItemToInventory, removeItemFromInventory, getItemCount } from './items.js';
+
+export const COOKING_INGREDIENTS = {
+  goldenWheat: {
+    id: 'goldenWheat',
+    name: 'Golden Wheat',
+    type: 'ingredient',
+    category: 'cooking',
+    rarity: 'Common',
+    description: 'Sun-kissed grain from the eastern fields.',
+    value: 3
+  },
+  wildMushroom: {
+    id: 'wildMushroom',
+    name: 'Wild Mushroom',
+    type: 'ingredient',
+    category: 'cooking',
+    rarity: 'Common',
+    description: 'A plump forest mushroom with earthy aroma.',
+    value: 4
+  },
+  dragonPepper: {
+    id: 'dragonPepper',
+    name: 'Dragon Pepper',
+    type: 'ingredient',
+    category: 'cooking',
+    rarity: 'Uncommon',
+    description: 'Fiery red pepper that burns the tongue.',
+    value: 8
+  },
+  moonMilk: {
+    id: 'moonMilk',
+    name: 'Moon Milk',
+    type: 'ingredient',
+    category: 'cooking',
+    rarity: 'Uncommon',
+    description: 'Silvery liquid collected under a full moon.',
+    value: 10
+  },
+  abyssalSalt: {
+    id: 'abyssalSalt',
+    name: 'Abyssal Salt',
+    type: 'ingredient',
+    category: 'cooking',
+    rarity: 'Rare',
+    description: 'Dark crystalline salt harvested from deep caverns.',
+    value: 15
+  },
+  fabergeSpice: {
+    id: 'fabergeSpice',
+    name: 'Fabergé Spice',
+    type: 'ingredient',
+    category: 'cooking',
+    rarity: 'Epic',
+    description:
+      'An ornate, jewel-toned spice of extraordinary rarity. Prized by master chefs across the realm.',
+    value: 50
+  },
+  starHoney: {
+    id: 'starHoney',
+    name: 'Star Honey',
+    type: 'ingredient',
+    category: 'cooking',
+    rarity: 'Rare',
+    description: 'Golden honey infused with celestial energy.',
+    value: 20
+  },
+  frostBerries: {
+    id: 'frostBerries',
+    name: 'Frost Berries',
+    type: 'ingredient',
+    category: 'cooking',
+    rarity: 'Uncommon',
+    description: 'Icy blue berries that never thaw.',
+    value: 7
+  },
+  sunflowerOil: {
+    id: 'sunflowerOil',
+    name: 'Sunflower Oil',
+    type: 'ingredient',
+    category: 'cooking',
+    rarity: 'Common',
+    description: 'Pressed from giant sunflowers, a basic cooking staple.',
+    value: 3
+  },
+  thunderRoot: {
+    id: 'thunderRoot',
+    name: 'Thunder Root',
+    type: 'ingredient',
+    category: 'cooking',
+    rarity: 'Rare',
+    description: 'A crackling tuber charged with lightning essence.',
+    value: 18
+  }
+};
+
+export const COOKING_RECIPES = [
+  {
+    id: 'fieldBread',
+    name: 'Field Bread',
+    description: 'A hearty loaf that restores vigor.',
+    ingredients: [
+      { id: 'goldenWheat', qty: 2 },
+      { id: 'sunflowerOil', qty: 1 }
+    ],
+    result: { type: 'consumable', heal: 25, name: 'Field Bread' },
+    difficulty: 1,
+    requiredLevel: 1
+  },
+  {
+    id: 'mushroomStew',
+    name: 'Mushroom Stew',
+    description: 'Thick savory stew that boosts defense.',
+    ingredients: [
+      { id: 'wildMushroom', qty: 2 },
+      { id: 'abyssalSalt', qty: 1 }
+    ],
+    result: { type: 'consumable', buff: { def: 5, duration: 3 }, name: 'Mushroom Stew' },
+    difficulty: 2,
+    requiredLevel: 3
+  },
+  {
+    id: 'sunnyDelight',
+    name: 'Sunny Delight',
+    description:
+      'A warm golden drink that fills you with radiant energy. Best served easy, over a morning fire.',
+    ingredients: [
+      { id: 'starHoney', qty: 1 },
+      { id: 'moonMilk', qty: 1 },
+      { id: 'sunflowerOil', qty: 1 }
+    ],
+    result: { type: 'consumable', buff: { atk: 8, spd: 4, duration: 5 }, name: 'Sunny Delight' },
+    difficulty: 3,
+    requiredLevel: 5
+  },
+  {
+    id: 'frostTonic',
+    name: 'Frost Tonic',
+    description: 'Chilling elixir that grants ice resistance.',
+    ingredients: [
+      { id: 'frostBerries', qty: 3 },
+      { id: 'moonMilk', qty: 1 }
+    ],
+    result: {
+      type: 'consumable',
+      buff: { def: 3, iceResist: 50, duration: 4 },
+      name: 'Frost Tonic'
+    },
+    difficulty: 2,
+    requiredLevel: 4
+  },
+  {
+    id: 'dragonfireSoup',
+    name: 'Dragonfire Soup',
+    description: 'Scorching broth that empowers fire attacks.',
+    ingredients: [
+      { id: 'dragonPepper', qty: 2 },
+      { id: 'thunderRoot', qty: 1 },
+      { id: 'abyssalSalt', qty: 1 }
+    ],
+    result: {
+      type: 'consumable',
+      buff: { atk: 10, fireBoost: 30, duration: 4 },
+      name: 'Dragonfire Soup'
+    },
+    difficulty: 3,
+    requiredLevel: 7
+  },
+  {
+    id: 'humptysFortuneStew',
+    name: "Humpty's Fortune Stew",
+    description:
+      'A legendary recipe said to have been devised by the great chef Humpty, who had a great fall from grace before rediscovering his passion. Restores full HP and grants luck.',
+    ingredients: [
+      { id: 'fabergeSpice', qty: 1 },
+      { id: 'starHoney', qty: 1 },
+      { id: 'goldenWheat', qty: 2 },
+      { id: 'moonMilk', qty: 1 }
+    ],
+    result: {
+      type: 'consumable',
+      heal: 999,
+      buff: { luck: 20, duration: 10 },
+      name: "Humpty's Fortune Stew"
+    },
+    difficulty: 5,
+    requiredLevel: 10
+  },
+  {
+    id: 'thunderBiscuit',
+    name: 'Thunder Biscuit',
+    description: 'Crackles with electric energy when bitten.',
+    ingredients: [
+      { id: 'thunderRoot', qty: 1 },
+      { id: 'goldenWheat', qty: 1 }
+    ],
+    result: { type: 'consumable', buff: { spd: 6, duration: 3 }, name: 'Thunder Biscuit' },
+    difficulty: 2,
+    requiredLevel: 4
+  },
+  {
+    id: 'overEasyElixir',
+    name: 'Over-Easy Elixir',
+    description:
+      'A smooth, balanced potion that slides down easy. Grants a relaxed focus in battle.',
+    ingredients: [
+      { id: 'sunflowerOil', qty: 2 },
+      { id: 'starHoney', qty: 1 },
+      { id: 'frostBerries', qty: 1 }
+    ],
+    result: {
+      type: 'consumable',
+      buff: { atk: 4, def: 4, spd: 4, duration: 6 },
+      name: 'Over-Easy Elixir'
+    },
+    difficulty: 3,
+    requiredLevel: 6
+  }
+];
+
+export function createCookingState() {
+  return {
+    discoveredRecipes: [],
+    cookingLevel: 1,
+    cookCount: {}
+  };
+}
+
+export function canCook(inventory, recipe) {
+  if (!recipe || !Array.isArray(recipe.ingredients)) return false;
+  const safeInventory = inventory || {};
+  return recipe.ingredients.every(({ id, qty }) => getItemCount(safeInventory, id) >= qty);
+}
+
+export function cookRecipe(state, inventory, recipeId) {
+  const recipe = COOKING_RECIPES.find((entry) => entry.id === recipeId);
+  if (!recipe) {
+    return { success: false, message: 'Missing ingredients' };
+  }
+  const safeInventory = inventory || {};
+  if (!canCook(safeInventory, recipe)) {
+    return { success: false, message: 'Missing ingredients' };
+  }
+
+  let updatedInventory = { ...safeInventory };
+  recipe.ingredients.forEach(({ id, qty }) => {
+    updatedInventory = removeItemFromInventory(updatedInventory, id, qty);
+  });
+  updatedInventory = addItemToInventory(updatedInventory, recipe.id, 1);
+
+  const newState = {
+    ...state,
+    cookCount: { ...(state?.cookCount || {}) }
+  };
+  newState.cookCount[recipe.id] = (newState.cookCount[recipe.id] || 0) + 1;
+
+  const totalCooks = Object.values(newState.cookCount).reduce((sum, count) => sum + count, 0);
+  newState.cookingLevel = 1 + Math.floor(totalCooks / 5);
+
+  return {
+    success: true,
+    state: newState,
+    inventory: updatedInventory,
+    message: `Cooked ${recipe.name}!`,
+    item: recipe.result
+  };
+}
+
+export function getCookingDrops(areaName, rng = Math.random) {
+  const drops = [];
+  const addDrop = (ingredientId, chance) => {
+    if (rng() < chance) {
+      const ingredient = COOKING_INGREDIENTS[ingredientId];
+      if (ingredient) {
+        drops.push({ ingredientId, quantity: 1, name: ingredient.name });
+      }
+    }
+  };
+
+  switch (areaName) {
+    case 'Eastern Fields':
+    case 'Village Square':
+      addDrop('goldenWheat', 0.3);
+      addDrop('sunflowerOil', 0.3);
+      break;
+    case 'Northwest Grove':
+      addDrop('wildMushroom', 0.25);
+      addDrop('frostBerries', 0.25);
+      break;
+    case 'Northeast Ridge':
+      addDrop('thunderRoot', 0.2);
+      addDrop('dragonPepper', 0.2);
+      break;
+    case 'Southwest Marsh':
+      addDrop('abyssalSalt', 0.2);
+      addDrop('moonMilk', 0.2);
+      break;
+    case 'Southern Road':
+      addDrop('starHoney', 0.15);
+      break;
+    case 'Southeast Dock':
+      addDrop('fabergeSpice', 0.05);
+      break;
+    default:
+      break;
+  }
+
+  return drops;
+}

--- a/tests/cooking-test.mjs
+++ b/tests/cooking-test.mjs
@@ -1,0 +1,194 @@
+import {
+  COOKING_INGREDIENTS,
+  COOKING_RECIPES,
+  createCookingState,
+  canCook,
+  cookRecipe,
+  getCookingDrops,
+} from '../src/cooking.js';
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition, name) {
+  if (condition) {
+    passed += 1;
+    console.log(`✅ ${name}`);
+  } else {
+    failed += 1;
+    console.error(`❌ ${name}`);
+  }
+}
+
+assert(
+  Object.keys(COOKING_INGREDIENTS).length === 10,
+  'COOKING_INGREDIENTS has 10 ingredients',
+);
+
+assert(
+  COOKING_RECIPES.length === 8,
+  'COOKING_RECIPES has 8 recipes',
+);
+
+assert(
+  Object.values(COOKING_INGREDIENTS).every(
+    (ingredient) =>
+      ingredient.id &&
+      ingredient.name &&
+      ingredient.type &&
+      ingredient.category &&
+      ingredient.rarity &&
+      ingredient.description &&
+      ingredient.value !== undefined,
+  ),
+  'Each ingredient has required fields',
+);
+
+assert(
+  COOKING_RECIPES.every(
+    (recipe) =>
+      recipe.id &&
+      recipe.name &&
+      recipe.description &&
+      recipe.ingredients &&
+      recipe.result &&
+      recipe.difficulty &&
+      recipe.requiredLevel !== undefined,
+  ),
+  'Each recipe has required fields',
+);
+
+const initialState = createCookingState();
+assert(
+  Array.isArray(initialState.discoveredRecipes) &&
+    initialState.cookingLevel === 1 &&
+    typeof initialState.cookCount === 'object',
+  'createCookingState returns valid initial state',
+);
+
+assert(
+  canCook({}, COOKING_RECIPES[0]) === false,
+  'canCook returns false with empty inventory',
+);
+
+assert(
+  canCook({ goldenWheat: 2, sunflowerOil: 1 }, COOKING_RECIPES[0]) === true,
+  'canCook returns true with sufficient ingredients',
+);
+
+assert(
+  canCook({ goldenWheat: 1, sunflowerOil: 1 }, COOKING_RECIPES[0]) === false,
+  'canCook returns false with insufficient ingredients',
+);
+
+assert(
+  canCook(null, COOKING_RECIPES[0]) === false,
+  'canCook handles null inventory',
+);
+
+assert(
+  canCook({}, null) === false,
+  'canCook handles null recipe',
+);
+
+assert(
+  cookRecipe({}, {}, 'nonexistent').success === false,
+  'cookRecipe returns failure for unknown recipe',
+);
+
+assert(
+  cookRecipe(createCookingState(), {}, 'fieldBread').success === false,
+  'cookRecipe returns failure with missing ingredients',
+);
+
+const successCook = cookRecipe(
+  createCookingState(),
+  { goldenWheat: 2, sunflowerOil: 1 },
+  'fieldBread',
+);
+
+assert(
+  successCook.success === true,
+  'cookRecipe succeeds with correct ingredients',
+);
+
+assert(
+  (successCook.inventory.goldenWheat === undefined || successCook.inventory.goldenWheat === 0) &&
+    (successCook.inventory.sunflowerOil === undefined || successCook.inventory.sunflowerOil === 0),
+  'cookRecipe removes ingredients from inventory',
+);
+
+assert(
+  successCook.inventory.fieldBread === 1,
+  'cookRecipe adds result item to inventory',
+);
+
+assert(
+  successCook.state.cookCount.fieldBread === 1,
+  'cookRecipe increments cookCount',
+);
+
+let levelState = createCookingState();
+let levelInventory = { goldenWheat: 2, sunflowerOil: 1 };
+for (let i = 0; i < 5; i += 1) {
+  const result = cookRecipe(levelState, levelInventory, 'fieldBread');
+  levelState = result.state;
+  levelInventory = result.inventory;
+  levelInventory.goldenWheat = (levelInventory.goldenWheat || 0) + 2;
+  levelInventory.sunflowerOil = (levelInventory.sunflowerOil || 0) + 1;
+}
+
+assert(
+  levelState.cookingLevel === 2,
+  'cookRecipe increases cookingLevel after 5 cooks',
+);
+
+assert(
+  Array.isArray(getCookingDrops('Eastern Fields')),
+  'getCookingDrops returns array',
+);
+
+const easternDrops = getCookingDrops('Eastern Fields', () => 0);
+assert(
+  easternDrops.length === 2 &&
+    easternDrops.some(d => d.ingredientId === 'goldenWheat') &&
+    easternDrops.some(d => d.ingredientId === 'sunflowerOil'),
+  'getCookingDrops returns drops for valid area with rng=0',
+);
+
+assert(
+  getCookingDrops('Eastern Fields', () => 1).length === 0,
+  'getCookingDrops returns empty for valid area with rng=1',
+);
+
+assert(
+  getCookingDrops('Unknown Area').length === 0,
+  'getCookingDrops returns empty for unknown area',
+);
+
+assert(
+  getCookingDrops('Southeast Dock', () => 0).some(d => d.ingredientId === 'fabergeSpice'),
+  'getCookingDrops Southeast Dock drops fabergeSpice with rng=0',
+);
+
+assert(
+  COOKING_RECIPES.every((recipe) =>
+    recipe.ingredients.every((ingredient) => COOKING_INGREDIENTS[ingredient.id]),
+  ),
+  'All recipe ingredient IDs exist in COOKING_INGREDIENTS',
+);
+
+const recipeIds = COOKING_RECIPES.map((recipe) => recipe.id);
+assert(
+  recipeIds.length === new Set(recipeIds).size,
+  'Recipes have unique IDs',
+);
+
+const ingredientIds = Object.values(COOKING_INGREDIENTS).map((ingredient) => ingredient.id);
+assert(
+  ingredientIds.length === new Set(ingredientIds).size,
+  'Ingredients have unique IDs',
+);
+
+console.log(`\n${passed} passed, ${failed} failed`);
+process.exit(failed > 0 ? 1 : 0);


### PR DESCRIPTION
## Cooking & Alchemy System

Adds a complete cooking/alchemy system to the RPG with 10 ingredients, 8 recipes, and full integration with the existing inventory system.

### New Features

**Ingredients (10 total):**
- Golden Wheat, Wild Mushroom, Dragon Pepper, Moon Milk, Abyssal Salt
- Fabergé Spice (Epic rarity), Star Honey, Frost Berries, Sunflower Oil, Thunder Root

**Recipes (8 total):**
| Recipe | Difficulty | Level | Effect |
|--------|-----------|-------|--------|
| Field Bread | 1 | 1 | Heal 25 HP |
| Mushroom Stew | 2 | 3 | +5 DEF (3 turns) |
| Sunny Delight | 3 | 5 | +8 ATK, +4 SPD (5 turns) |
| Frost Tonic | 2 | 4 | +3 DEF, 50% ice resist (4 turns) |
| Dragonfire Soup | 3 | 7 | +10 ATK, 30% fire boost (4 turns) |
| Humpty's Fortune Stew | 5 | 10 | Full heal + luck buff |
| Thunder Biscuit | 2 | 4 | +6 SPD (3 turns) |
| Over-Easy Elixir | 3 | 6 | +4 ATK/DEF/SPD (6 turns) |

**Systems:**
- `createCookingState()` - Initialize cooking state
- `canCook(inventory, recipe)` - Check ingredient availability
- `cookRecipe(state, inventory, recipeId)` - Cook a recipe, consume ingredients, get result
- `getCookingDrops(areaName, rng)` - Area-based ingredient drops

**Area Drop Locations:**
- Eastern Fields/Village Square: Golden Wheat, Sunflower Oil
- Northwest Grove: Wild Mushroom, Frost Berries
- Northeast Ridge: Thunder Root, Dragon Pepper
- Southwest Marsh: Abyssal Salt, Moon Milk
- Southern Road: Star Honey
- Southeast Dock: Fabergé Spice (5% - very rare)

### Tests
25 tests covering all functions, edge cases, and data integrity.

### Security
Scanner passes clean (0 issues).
